### PR TITLE
Add UTF‑8 case classification macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ macro-features:
  - [X] IF_NULL
  - [X] IF_NOT_NULL
  - [X] DIE 
-- [X] UNUSED
-- [X] ALIGN_UP
-- [X] BIT
-- [X] PLAT_X (platform macros)
-- [X] ARRAY_LEN
+ - [X] UNUSED
+ - [X] ALIGN_UP
+ - [X] BIT
+ - [X] PLAT_X (platform macros)
+ - [X] ARRAY_LEN
 
 object-features:
  - [X] generic optional
@@ -40,8 +40,8 @@ collection-features:
  - [ ] ring buffer 
 
  method-features:
- - [ ] hashing methods FNV-1A, Murmur3, SipHash (tied to hashmap, stil separate)
-- [ ] utf8 utility methods
+ - [X] hashing methods FNV-1A, Murmur3, SipHash (tied to hashmap, stil separate)
+ - [X] utf8 utility methods
 
 ## Allocators
 All methods or datastructures that need an allocator should accept the generic allocator interface in a zig style 
@@ -52,7 +52,7 @@ Code must be written and formatted in a `clang-format`-friendly way.
 All methods and structs that do not represent standard library types (e.g. `Int_Optional`) must be prefixed with `cu_`. This prefix is followed by the category (e.g. `Allocator`) and finally the actual type or function name.
 
 Example:
-- `PageAllocator` → `cu_Allocator_PageAllocator`
+ - `PageAllocator` → `cu_Allocator_PageAllocator`
 
 The same naming convention applies to functions.
 

--- a/example.c
+++ b/example.c
@@ -1,6 +1,8 @@
+#include "hash/hash.h"
 #include "memory/allocator.h"
 #include "memory/page.h"
 #include "object/slice.h"
+#include "string/utf8.h"
 #include <stdalign.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -18,6 +20,28 @@ int main(void) {
 
   fprintf(stderr, "allocation successful!\n");
   cu_Allocator_Free(page_allocator, allocation.value);
+
+  const char *text = "hello";
+  bool valid = cu_utf8_validate((const unsigned char *)text, 5);
+  uint64_t hash = cu_Hash_FNV1a64(text, 5);
+  uint32_t cp = 0;
+  cu_utf8_decode((const unsigned char *)text, 5, &cp);
+  switch (cu_utf8_case(cp)) {
+  case CU_UTF8_CASE_DIGIT:
+    fprintf(stderr, "first char is digit\n");
+    break;
+  case CU_UTF8_CASE_UPPER:
+    fprintf(stderr, "first char is upper\n");
+    break;
+  case CU_UTF8_CASE_LOWER:
+    fprintf(stderr, "first char is lower\n");
+    break;
+  default:
+    fprintf(stderr, "first char other\n");
+    break;
+  }
+  fprintf(stderr, "utf8 valid: %s, hash: %llu\n", valid ? "yes" : "no",
+      (unsigned long long)hash);
 
   exit(EXIT_SUCCESS);
 }

--- a/include/cute.h
+++ b/include/cute.h
@@ -7,4 +7,6 @@
 #include "object/result.h"
 #include "object/slice.h"
 
+#include "string/utf8.h"
+#include "hash/hash.h"
 #include "macro.h"

--- a/include/hash/hash.h
+++ b/include/hash/hash.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+/** \brief 32-bit FNV-1a offset basis. */
+#define CU_FNV1A32_OFFSET_BASIS 2166136261u
+/** \brief 32-bit FNV-1a prime. */
+#define CU_FNV1A32_PRIME 16777619u
+
+/** \brief 64-bit FNV-1a offset basis. */
+#define CU_FNV1A64_OFFSET_BASIS 14695981039346656037ull
+/** \brief 64-bit FNV-1a prime. */
+#define CU_FNV1A64_PRIME 1099511628211ull
+
+/** \brief Murmur3 constant c1. */
+#define CU_MURMUR3_C1 0xcc9e2d51u
+/** \brief Murmur3 constant c2. */
+#define CU_MURMUR3_C2 0x1b873593u
+/** \brief Murmur3 constant used during mixing. */
+#define CU_MURMUR3_N 0xe6546b64u
+/** \brief Murmur3 finalization constant 1. */
+#define CU_MURMUR3_F1 0x85ebca6bu
+/** \brief Murmur3 finalization constant 2. */
+#define CU_MURMUR3_F2 0xc2b2ae35u
+
+/** \brief SipHash initial v0 constant. */
+#define CU_SIPHASH_V0_INIT 0x736f6d6570736575ull
+/** \brief SipHash initial v1 constant. */
+#define CU_SIPHASH_V1_INIT 0x646f72616e646f6dull
+/** \brief SipHash initial v2 constant. */
+#define CU_SIPHASH_V2_INIT 0x6c7967656e657261ull
+/** \brief SipHash initial v3 constant. */
+#define CU_SIPHASH_V3_INIT 0x7465646279746573ull
+
+/**
+ * \brief Compute a 32-bit FNV-1a hash.
+ *
+ * \param data input bytes
+ * \param len number of bytes
+ */
+uint32_t cu_Hash_FNV1a32(const void *data, size_t len);
+/** \brief Compute a 64-bit FNV-1a hash. */
+uint64_t cu_Hash_FNV1a64(const void *data, size_t len);
+
+/**\brief Compute a 32-bit Murmur3 hash. */
+uint32_t cu_Hash_Murmur3_32(const void *data, size_t len, uint32_t seed);
+
+/**\brief Compute SipHash-2-4. */
+uint64_t cu_Hash_SipHash24(const uint8_t key[16], const void *data, size_t len);

--- a/include/string/utf8.h
+++ b/include/string/utf8.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/** \brief True if the codepoint represents an ASCII digit. */
+#define CU_UTF8_IS_DIGIT(cp) ((cp) >= '0' && (cp) <= '9')
+/** \brief True if the codepoint is an ASCII uppercase letter. */
+#define CU_UTF8_IS_UPPER(cp) ((cp) >= 'A' && (cp) <= 'Z')
+/** \brief True if the codepoint is an ASCII lowercase letter. */
+#define CU_UTF8_IS_LOWER(cp) ((cp) >= 'a' && (cp) <= 'z')
+/** \brief True if the codepoint is an ASCII alphabetic character. */
+#define CU_UTF8_IS_ALPHA(cp) (CU_UTF8_IS_UPPER(cp) || CU_UTF8_IS_LOWER(cp))
+/** \brief True if the codepoint is an ASCII alphanumeric character. */
+#define CU_UTF8_IS_ALNUM(cp) (CU_UTF8_IS_ALPHA(cp) || CU_UTF8_IS_DIGIT(cp))
+/** \brief True if the codepoint is an ASCII whitespace character. */
+#define CU_UTF8_IS_SPACE(cp)                                                   \
+  ((cp) == ' ' || (cp) == '\t' || (cp) == '\n' || (cp) == '\r' ||              \
+      (cp) == '\f' || (cp) == '\v')
+
+/** \brief Classification result for codepoints with no special category. */
+#define CU_UTF8_CASE_OTHER 0x00u
+/** \brief Classification result for ASCII digits. */
+#define CU_UTF8_CASE_DIGIT 0x8fu
+/** \brief Classification result for ASCII uppercase letters. */
+#define CU_UTF8_CASE_UPPER 0x90u
+/** \brief Classification result for ASCII lowercase letters. */
+#define CU_UTF8_CASE_LOWER 0x91u
+/** \brief Classification result for ASCII whitespace. */
+#define CU_UTF8_CASE_SPACE 0x92u
+
+/**
+ * \brief Decode the next UTF-8 codepoint.
+ *
+ * Returns the number of bytes consumed or zero on failure.
+ */
+size_t cu_utf8_decode(const unsigned char *s, size_t len, uint32_t *codepoint);
+/** \brief Validate a UTF-8 byte sequence. */
+bool cu_utf8_validate(const unsigned char *s, size_t len);
+/** \brief Count UTF-8 codepoints in a buffer. */
+size_t cu_utf8_codepoint_count(const unsigned char *s, size_t len);
+/** \brief Classify a codepoint into switch-friendly categories. */
+uint8_t cu_utf8_case(uint32_t codepoint);

--- a/lib/hash/hash.c
+++ b/lib/hash/hash.c
@@ -1,0 +1,153 @@
+#include "hash/hash.h"
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+/** Compute the 32-bit FNV-1a hash of a buffer. */
+uint32_t cu_Hash_FNV1a32(const void *data, size_t len) {
+  const uint8_t *bytes = (const uint8_t *)data;
+  uint32_t hash = CU_FNV1A32_OFFSET_BASIS;
+  for (size_t i = 0; i < len; ++i) {
+    hash ^= bytes[i];
+    hash *= CU_FNV1A32_PRIME;
+  }
+  return hash;
+}
+
+/** Compute the 64-bit FNV-1a hash of a buffer. */
+uint64_t cu_Hash_FNV1a64(const void *data, size_t len) {
+  const uint8_t *bytes = (const uint8_t *)data;
+  uint64_t hash = CU_FNV1A64_OFFSET_BASIS;
+  for (size_t i = 0; i < len; ++i) {
+    hash ^= bytes[i];
+    hash *= CU_FNV1A64_PRIME;
+  }
+  return hash;
+}
+
+/** Compute the 32-bit Murmur3 hash of a buffer. */
+uint32_t cu_Hash_Murmur3_32(const void *data, size_t len, uint32_t seed) {
+  const uint8_t *bytes = (const uint8_t *)data;
+  uint32_t h1 = seed;
+  const uint32_t c1 = CU_MURMUR3_C1;
+  const uint32_t c2 = CU_MURMUR3_C2;
+  size_t i = 0;
+  while (len - i >= 4) {
+    uint32_t k1;
+    memcpy(&k1, bytes + i, 4);
+    k1 *= c1;
+    k1 = (k1 << 15) | (k1 >> 17);
+    k1 *= c2;
+
+    h1 ^= k1;
+    h1 = (h1 << 13) | (h1 >> 19);
+    h1 = h1 * 5 + CU_MURMUR3_N;
+    i += 4;
+  }
+
+  uint32_t k1 = 0;
+  switch (len & 3) {
+  case 3:
+    k1 ^= bytes[i + 2] << 16;
+    /* fallthrough */
+  case 2:
+    k1 ^= bytes[i + 1] << 8;
+    /* fallthrough */
+  case 1:
+    k1 ^= bytes[i];
+    k1 *= c1;
+    k1 = (k1 << 15) | (k1 >> 17);
+    k1 *= c2;
+    h1 ^= k1;
+  }
+
+  h1 ^= (uint32_t)len;
+
+  h1 ^= h1 >> 16;
+  h1 *= CU_MURMUR3_F1;
+  h1 ^= h1 >> 13;
+  h1 *= CU_MURMUR3_F2;
+  h1 ^= h1 >> 16;
+
+  return h1;
+}
+
+static inline uint64_t cu_hash_read64(const uint8_t *p) {
+  uint64_t v;
+  memcpy(&v, p, 8);
+  return v;
+}
+
+#define SIPROUND                                                             \
+  do {                                                                       \
+    v0 += v1;                                                                \
+    v1 = (v1 << 13) | (v1 >> 51);                                            \
+    v1 ^= v0;                                                                \
+    v0 = (v0 << 32) | (v0 >> 32);                                            \
+    v2 += v3;                                                                \
+    v3 = (v3 << 16) | (v3 >> 48);                                            \
+    v3 ^= v2;                                                                \
+    v0 += v3;                                                                \
+    v3 = (v3 << 21) | (v3 >> 43);                                            \
+    v3 ^= v0;                                                                \
+    v2 += v1;                                                                \
+    v1 = (v1 << 17) | (v1 >> 47);                                            \
+    v1 ^= v2;                                                                \
+    v2 = (v2 << 32) | (v2 >> 32);                                            \
+  } while (0)
+
+/** Compute SipHash-2-4 for the given input. */
+uint64_t cu_Hash_SipHash24(const uint8_t key[16], const void *data, size_t len) {
+  uint64_t k0 = cu_hash_read64(key);
+  uint64_t k1 = cu_hash_read64(key + 8);
+  uint64_t v0 = CU_SIPHASH_V0_INIT ^ k0;
+  uint64_t v1 = CU_SIPHASH_V1_INIT ^ k1;
+  uint64_t v2 = CU_SIPHASH_V2_INIT ^ k0;
+  uint64_t v3 = CU_SIPHASH_V3_INIT ^ k1;
+
+  const uint8_t *in = (const uint8_t *)data;
+  size_t i = 0;
+  while (len - i >= 8) {
+    uint64_t m = cu_hash_read64(in + i);
+    v3 ^= m;
+    SIPROUND;
+    SIPROUND;
+    v0 ^= m;
+    i += 8;
+  }
+
+  uint64_t b = ((uint64_t)len) << 56;
+  switch (len & 7) {
+  case 7:
+    b |= ((uint64_t)in[i + 6]) << 48;
+    /* fallthrough */
+  case 6:
+    b |= ((uint64_t)in[i + 5]) << 40;
+    /* fallthrough */
+  case 5:
+    b |= ((uint64_t)in[i + 4]) << 32;
+    /* fallthrough */
+  case 4:
+    b |= ((uint64_t)in[i + 3]) << 24;
+    /* fallthrough */
+  case 3:
+    b |= ((uint64_t)in[i + 2]) << 16;
+    /* fallthrough */
+  case 2:
+    b |= ((uint64_t)in[i + 1]) << 8;
+    /* fallthrough */
+  case 1:
+    b |= ((uint64_t)in[i]);
+  }
+
+  v3 ^= b;
+  SIPROUND;
+  SIPROUND;
+  v0 ^= b;
+  v2 ^= 0xff;
+  SIPROUND;
+  SIPROUND;
+  SIPROUND;
+  SIPROUND;
+  return v0 ^ v1 ^ v2 ^ v3;
+}

--- a/lib/string/utf8.c
+++ b/lib/string/utf8.c
@@ -1,0 +1,97 @@
+#include "string/utf8.h"
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+/** \brief Helper to read a 32-bit value from an unaligned pointer. */
+static inline uint32_t cu_utf8_read_uint32(const unsigned char *p) {
+  uint32_t v = 0;
+  memcpy(&v, p, sizeof(uint32_t));
+  return v;
+}
+
+/** Decode one UTF-8 codepoint from a buffer. */
+size_t cu_utf8_decode(const unsigned char *s, size_t len, uint32_t *codepoint) {
+  if (len == 0) {
+    return 0;
+  }
+
+  unsigned char c0 = s[0];
+  if (c0 < 0x80) {
+    if (codepoint) {
+      *codepoint = c0;
+    }
+    return 1;
+  } else if ((c0 & 0xe0) == 0xc0) {
+    if (len < 2)
+      return 0;
+    if ((s[1] & 0xc0) != 0x80)
+      return 0;
+    if (codepoint) {
+      *codepoint = ((c0 & 0x1f) << 6) | (s[1] & 0x3f);
+    }
+    return 2;
+  } else if ((c0 & 0xf0) == 0xe0) {
+    if (len < 3)
+      return 0;
+    if ((s[1] & 0xc0) != 0x80 || (s[2] & 0xc0) != 0x80)
+      return 0;
+    if (codepoint) {
+      *codepoint = ((c0 & 0x0f) << 12) | ((s[1] & 0x3f) << 6) | (s[2] & 0x3f);
+    }
+    return 3;
+  } else if ((c0 & 0xf8) == 0xf0) {
+    if (len < 4)
+      return 0;
+    if ((s[1] & 0xc0) != 0x80 || (s[2] & 0xc0) != 0x80 || (s[3] & 0xc0) != 0x80)
+      return 0;
+    if (codepoint) {
+      *codepoint = ((c0 & 0x07) << 18) | ((s[1] & 0x3f) << 12) |
+                   ((s[2] & 0x3f) << 6) | (s[3] & 0x3f);
+    }
+    return 4;
+  }
+
+  return 0;
+}
+
+/** Validate a UTF-8 byte sequence. */
+bool cu_utf8_validate(const unsigned char *s, size_t len) {
+  size_t i = 0;
+  while (i < len) {
+    size_t step = cu_utf8_decode(s + i, len - i, NULL);
+    if (step == 0) {
+      return false;
+    }
+    i += step;
+  }
+  return true;
+}
+
+/** Count the codepoints in a UTF-8 string. */
+size_t cu_utf8_codepoint_count(const unsigned char *s, size_t len) {
+  size_t i = 0;
+  size_t count = 0;
+  while (i < len) {
+    size_t step = cu_utf8_decode(s + i, len - i, NULL);
+    if (step == 0) {
+      return 0;
+    }
+    i += step;
+    count++;
+  }
+  return count;
+}
+
+/** Classify a codepoint for switch cases. */
+uint8_t cu_utf8_case(uint32_t codepoint) {
+  if (CU_UTF8_IS_DIGIT(codepoint))
+    return CU_UTF8_CASE_DIGIT;
+  if (CU_UTF8_IS_UPPER(codepoint))
+    return CU_UTF8_CASE_UPPER;
+  if (CU_UTF8_IS_LOWER(codepoint))
+    return CU_UTF8_CASE_LOWER;
+  if (CU_UTF8_IS_SPACE(codepoint))
+    return CU_UTF8_CASE_SPACE;
+  return CU_UTF8_CASE_OTHER;
+}

--- a/meson.build
+++ b/meson.build
@@ -10,6 +10,8 @@ sources = [
   'lib/object/optional.c',
   'lib/memory/allocator.c',
   'lib/memory/page.c',
+  'lib/string/utf8.c',
+  'lib/hash/hash.c',
 ]
 
 cute_lib = library(


### PR DESCRIPTION
## Summary
- add constants to classify UTF‑8 codepoints for switch statements
- implement `cu_utf8_case` to return these constants
- show classification in the example program

## Testing
- `python3 meson-1.8.2/meson.py setup build`
- `ninja -C build`
- `./build/cute_test`


------
https://chatgpt.com/codex/tasks/task_e_6868c642973483338fd64f8bc08c2c5a