### PR TITLE
Add docs deployment pipelines

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,20 +1,39 @@
-# deploy step can be copied like this and parameters adjusted if needed but these are from the lattest official github docs
-# your information may be outdated but this is up to date 
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+name: docs
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y doxygen graphviz meson ninja-build
+      - name: Generate documentation
+        run: |
+          meson setup build
+          ninja -C build docs
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          # Upload entire repository
-          path: '.'
+          path: build/docs/html
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.gitlab-ci.yaml
+++ b/.gitlab-ci.yaml
@@ -1,0 +1,14 @@
+image: debian:stable
+
+pages:
+  stage: deploy
+  script:
+    - apt-get update && apt-get install -y doxygen graphviz meson ninja-build
+    - meson setup build
+    - ninja -C build docs
+    - mv build/docs/html public
+  artifacts:
+    paths:
+      - public
+  only:
+    - main

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 ### Documentation
 
 - add doxygen comments for public headers and enable graphviz support
+- setup GitHub and GitLab Pages deployment
 
 ### Macros
 

--- a/README.md
+++ b/README.md
@@ -97,4 +97,15 @@ final version
 
 This style is compatible with the changelog generator (`git-cliff.toml`) and ensures readable release notes.
 
+## Documentation
+
+Documentation is generated with Doxygen. When changes are pushed to the `main`
+branch, GitHub Actions and GitLab CI build the docs and publish them through
+GitHub Pages and GitLab Pages. Locally you can run:
+
+```sh
+meson setup build
+ninja -C build docs
+```
+
 


### PR DESCRIPTION
## Summary
- set up GitHub Actions workflow to build Doxygen docs and deploy to Pages
- configure GitLab CI for Pages deployment
- document docs generation in README
- note page deployment in CHANGELOG

## Testing
- `python3 meson-1.8.2/meson.py setup build`
- `ninja -C build docs`

------
https://chatgpt.com/codex/tasks/task_e_68694ded328c8333b386ef305c7b6832