### PR TITLE
implement general purpose allocator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ All notable changes to this project will be documented in this file. See [conven
 
 - adds changelog - ([50e2d9a](https://git.schaub-dev.xyz/cppuniverse/libcute/commit/50e2d9abe8f10fd4afcc764475bcb4258ca85edb)) - Fabrice
 - adds bitset, starts implementing gpa, fixes macros - ([931d391](https://git.schaub-dev.xyz/cppuniverse/libcute/commit/931d391a6551b651af0f4170bf7e3d2b792b5440)) - Fabrice
+- general purpose allocator allows custom backing allocator - Codex
+- GP allocator config uses optional backing allocator - Codex
 
 ### Refactoring
 

--- a/example.c
+++ b/example.c
@@ -1,10 +1,14 @@
-#include "memory/allocator.h"
+#include "memory/gpallocator.h"
 #include "string/string.h"
 #include <stdio.h>
 #include <stdlib.h>
 
 int main(void) {
-  cu_Allocator alloc = cu_Allocator_CAllocator();
+  cu_GPAllocator gpa;
+  cu_GPAllocator_Config cfg = {0};
+  cfg.backingAllocator = cu_Allocator_none();
+  cfg.bucketSize = 64;
+  cu_Allocator alloc = cu_Allocator_GPAllocator(&gpa, cfg);
 
   cu_String_Result res = cu_String_from_cstr(alloc, "hello");
   if (!cu_String_result_is_ok(&res)) {
@@ -17,5 +21,6 @@ int main(void) {
   printf("%s\n", hello.data);
 
   cu_String_destroy(&hello);
+  cu_GPAllocator_destroy(&gpa);
   return EXIT_SUCCESS;
 }

--- a/include/cute.h
+++ b/include/cute.h
@@ -4,6 +4,7 @@
 
 #include "memory/allocator.h"
 #include "memory/page.h"
+#include "memory/gpallocator.h"
 
 #include "hash/hash.h"
 #include "macro.h"

--- a/include/macro.h
+++ b/include/macro.h
@@ -25,6 +25,23 @@
 /** Create a bit mask with bit @p x set. */
 #define CU_BIT(x) (1u << (x))
 
+/** Round up to the next power of two. */
+static inline size_t cu_next_pow2(size_t x) {
+  if (x <= 1) {
+    return 1;
+  }
+  x--;
+  x |= x >> 1;
+  x |= x >> 2;
+  x |= x >> 4;
+  x |= x >> 8;
+  x |= x >> 16;
+#if SIZE_MAX > UINT32_MAX
+  x |= x >> 32;
+#endif
+  return x + 1;
+}
+
 /** Platform detection macros. */
 #if defined(_WIN32) || defined(_WIN64)
 /** Defined on Windows systems */

--- a/include/memory/allocator.h
+++ b/include/memory/allocator.h
@@ -42,3 +42,5 @@ static inline void cu_Allocator_Free(cu_Allocator allocator, cu_Slice mem) {
 
 /** Standard allocator backed by malloc and free. */
 cu_Allocator cu_Allocator_CAllocator(void);
+
+CU_OPTIONAL_DECL(cu_Allocator, cu_Allocator)

--- a/include/memory/gpallocator.h
+++ b/include/memory/gpallocator.h
@@ -1,40 +1,60 @@
 #pragma once
 
+/** @file gpallocator.h General purpose allocator. */
+
 #include "memory/allocator.h"
 #include "object/bitset.h"
+#include <stdbool.h>
+#include <stddef.h>
 
-#define CU_BUCKET_SIZE 4096
-#define CU_NUM_SMALL_BUCKETS                                                   \
-  16 // **< Number of small buckets, must be a power of 2 and cannot be
-     // overridden. */
-#define CU_NUM_LARGE_BUCKETS                                                   \
-  8 // **< Number of large buckets, must be a power of 2 and cannot be
-    // overridden. */
-#define CU_BUCKET_CANARY                                                       \
-  0x9232a6ff85dff10f // **< Canary value for bucket headers to detect
-                     // corruption. */
+#define CU_GPA_BUCKET_SIZE 4096     /**< default page size for buckets */
+#define CU_GPA_NUM_SMALL_BUCKETS 16 /**< number of size classes */
+#define CU_GPA_CANARY 0x9232a6ff85dff10fULL /**< bucket canary value */
 
-struct cu_GPAllocator_BucketHeader;
+CU_BITSET_DECL(cu_GPAllocator_UsedBits, CU_GPA_BUCKET_SIZE)
 
-CU_BITSET_DECL(cu_GPAllocator_BucketHeader, CU_BUCKET_SIZE)
-CU_OPTIONAL_DECL(
-    cu_GPAllocator_BucketHeaderPtr, struct cu_GPAllocator_BucketHeader *)
+typedef struct cu_GPAllocator_BucketHeader cu_GPAllocator_BucketHeader;
 
+/** Object pool used by buckets to track slot usage. */
+typedef struct {
+  cu_GPAllocator_UsedBits_BitSet used; /**< slot usage bitset */
+  unsigned char *data;                 /**< pointer to slot memory */
+  size_t objectSize;                   /**< size of each object */
+  size_t slotCount;                    /**< total slots */
+  size_t usedCount;                    /**< number of used slots */
+} cu_GPAllocator_ObjectPool;
+
+/** Metadata for a single bucket of small allocations. */
 struct cu_GPAllocator_BucketHeader {
-  cu_GPAllocator_BucketHeader_BitSet freeSlots;
-  cu_GPAllocator_BucketHeaderPtr_Optional prevBucket;
-  cu_GPAllocator_BucketHeaderPtr_Optional nextBucket;
-  size_t canary;
+  cu_GPAllocator_BucketHeader *prev; /**< previous bucket */
+  cu_GPAllocator_BucketHeader *next; /**< next bucket */
+  cu_GPAllocator_ObjectPool objects; /**< slot storage information */
+  size_t canary;                     /**< header corruption check */
 };
 
-struct cu_GPAllocator_LargeAlloc {};
+/** Metadata for large allocations. */
+typedef struct cu_GPALargeAlloc {
+  struct cu_GPALargeAlloc *prev; /**< previous entry */
+  struct cu_GPALargeAlloc *next; /**< next entry */
+  cu_Slice slice;                /**< allocated memory slice */
+} cu_GPALargeAlloc;
+
+/** Runtime state for the general purpose allocator. */
+typedef struct {
+  cu_Allocator backingAllocator; /**< allocator used for all bookkeeping */
+  cu_GPAllocator_BucketHeader *smallBuckets[CU_GPA_NUM_SMALL_BUCKETS];
+  cu_GPALargeAlloc *largeAllocs; /**< linked list of large allocations */
+  size_t bucketSize;             /**< requested bucket size */
+} cu_GPAllocator;
 
 typedef struct {
-  size_t
-      bucketSize; /**< Size of each bucket in bytes. Overrides BUCKET_SIZE. */
+  size_t bucketSize;                      /**< desired bucket size */
+  cu_Allocator_Optional backingAllocator; /**< custom backing allocator */
 } cu_GPAllocator_Config;
 
-typedef struct {
-  cu_Allocator backingAllocator;
-  struct cu_GPAllocator_BucketHeader *smallBuckets[CU_NUM_SMALL_BUCKETS];
-} cu_Allocator_GPAllocator;
+/** Create a GP allocator using the given configuration. */
+cu_Allocator cu_Allocator_GPAllocator(
+    cu_GPAllocator *alloc, cu_GPAllocator_Config config);
+
+/** Release all buckets and large allocations. */
+void cu_GPAllocator_destroy(cu_GPAllocator *alloc);

--- a/lib/memory/allocator.c
+++ b/lib/memory/allocator.c
@@ -62,3 +62,5 @@ cu_Allocator cu_Allocator_CAllocator(void) {
   allocator.freeFn = cu_CAllocator_Free;
   return allocator;
 }
+
+CU_OPTIONAL_IMPL(cu_Allocator, cu_Allocator)

--- a/lib/memory/gpalloactor.c
+++ b/lib/memory/gpalloactor.c
@@ -1,5 +1,0 @@
-#include "memory/gpallocator.h"
-#include "object/bitset.h"
-
-CU_BITSET_IMPL(
-    cu_GPAllocator_BucketHeader, NUM_SMALL_BUCKETS + NUM_LARGE_BUCKETS);

--- a/lib/memory/gpallocator.c
+++ b/lib/memory/gpallocator.c
@@ -1,0 +1,310 @@
+#include "memory/gpallocator.h"
+#include "macro.h"
+#include <string.h>
+
+CU_BITSET_IMPL(cu_GPAllocator_UsedBits, CU_GPA_BUCKET_SIZE);
+
+/* Helper forward declarations */
+static cu_Slice_Optional cu_gpa_alloc(
+    void *self, size_t size, size_t alignment);
+static cu_Slice_Optional cu_gpa_resize(
+    void *self, cu_Slice mem, size_t size, size_t alignment);
+static void cu_gpa_free(void *self, cu_Slice mem);
+
+/* -------------------------------------------------------------------------- */
+/* Utility functions                                                          */
+/* -------------------------------------------------------------------------- */
+
+static size_t cu_gpa_calc_slot_count(cu_GPAllocator *gpa, size_t obj_size) {
+  size_t max_data = gpa->bucketSize ? gpa->bucketSize : CU_GPA_BUCKET_SIZE;
+  size_t count = max_data / obj_size;
+  if (count == 0) {
+    count = 1;
+  }
+  size_t bit_cap = cu_GPAllocator_UsedBits_size();
+  return count > bit_cap ? bit_cap : count;
+}
+
+static cu_GPAllocator_BucketHeader *cu_gpa_create_bucket(
+    cu_GPAllocator *gpa, size_t obj_size) {
+  size_t slot_count = cu_gpa_calc_slot_count(gpa, obj_size);
+  size_t total = sizeof(cu_GPAllocator_BucketHeader) + slot_count * obj_size;
+  cu_Slice_Optional mem =
+      cu_Allocator_Alloc(gpa->backingAllocator, total, obj_size);
+  if (cu_Slice_is_none(&mem)) {
+    return NULL;
+  }
+
+  cu_GPAllocator_BucketHeader *bucket =
+      (cu_GPAllocator_BucketHeader *)mem.value.ptr;
+  bucket->prev = NULL;
+  bucket->next = NULL;
+  cu_GPAllocator_UsedBits_clear_all(&bucket->objects.used);
+  bucket->objects.data = (unsigned char *)(bucket + 1);
+  bucket->objects.objectSize = obj_size;
+  bucket->objects.slotCount = slot_count;
+  bucket->objects.usedCount = 0;
+  bucket->canary = CU_GPA_CANARY;
+  return bucket;
+}
+
+static int cu_gpa_index_from_size(size_t size) {
+  int idx = 0;
+  size_t s = 1;
+  while (s < size && idx < CU_GPA_NUM_SMALL_BUCKETS) {
+    s <<= 1;
+    idx++;
+  }
+  return (idx < CU_GPA_NUM_SMALL_BUCKETS) ? idx : -1;
+}
+
+static cu_GPAllocator_BucketHeader *cu_gpa_find_bucket(
+    cu_GPAllocator *gpa, void *ptr, size_t *slot_out) {
+  for (int i = 0; i < CU_GPA_NUM_SMALL_BUCKETS; ++i) {
+    cu_GPAllocator_BucketHeader *b = gpa->smallBuckets[i];
+    while (b) {
+      uintptr_t start = (uintptr_t)b->objects.data;
+      uintptr_t end = start + b->objects.objectSize * b->objects.slotCount;
+      if ((uintptr_t)ptr >= start && (uintptr_t)ptr < end) {
+        if (slot_out) {
+          *slot_out = ((uintptr_t)ptr - start) / b->objects.objectSize;
+        }
+        return b;
+      }
+      b = b->next;
+    }
+  }
+  return NULL;
+}
+
+static cu_GPALargeAlloc *cu_gpa_find_large(cu_GPAllocator *gpa, void *ptr) {
+  cu_GPALargeAlloc *cur = gpa->largeAllocs;
+  while (cur) {
+    if (cur->slice.ptr == ptr) {
+      return cur;
+    }
+    cur = cur->next;
+  }
+  return NULL;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Allocation paths */
+/* -------------------------------------------------------------------------- */
+
+static cu_Slice_Optional cu_gpa_alloc_small(cu_GPAllocator *gpa, size_t size,
+    size_t alignment, size_t obj_size, int idx) {
+  cu_GPAllocator_BucketHeader *bucket = gpa->smallBuckets[idx];
+  while (bucket && bucket->objects.usedCount == bucket->objects.slotCount) {
+    bucket = bucket->next;
+  }
+
+  if (!bucket) {
+    bucket = cu_gpa_create_bucket(gpa, obj_size);
+    if (!bucket) {
+      return cu_Slice_none();
+    }
+    bucket->next = gpa->smallBuckets[idx];
+    if (bucket->next) {
+      bucket->next->prev = bucket;
+    }
+    gpa->smallBuckets[idx] = bucket;
+  }
+
+  size_t slot = 0;
+  for (; slot < bucket->objects.slotCount; ++slot) {
+    if (!cu_GPAllocator_UsedBits_is_set(&bucket->objects.used, slot)) {
+      break;
+    }
+  }
+  if (slot == bucket->objects.slotCount) {
+    return cu_Slice_none();
+  }
+  cu_GPAllocator_UsedBits_set(&bucket->objects.used, slot);
+  bucket->objects.usedCount++;
+  void *ptr = bucket->objects.data + slot * bucket->objects.objectSize;
+  CU_UNUSED(alignment);
+  return cu_Slice_some(cu_Slice_create(ptr, size));
+}
+
+static cu_Slice_Optional cu_gpa_alloc_large(
+    cu_GPAllocator *gpa, size_t size, size_t alignment) {
+  cu_Slice_Optional mem =
+      cu_Allocator_Alloc(gpa->backingAllocator, size, alignment);
+  if (cu_Slice_is_none(&mem)) {
+    return cu_Slice_none();
+  }
+  cu_Slice_Optional meta_mem = cu_Allocator_Alloc(
+      gpa->backingAllocator, sizeof(cu_GPALargeAlloc), sizeof(void *));
+  if (cu_Slice_is_none(&meta_mem)) {
+    cu_Allocator_Free(gpa->backingAllocator, mem.value);
+    return cu_Slice_none();
+  }
+  cu_GPALargeAlloc *meta = (cu_GPALargeAlloc *)meta_mem.value.ptr;
+  meta->slice = mem.value;
+  meta->prev = NULL;
+  meta->next = gpa->largeAllocs;
+  if (meta->next) {
+    meta->next->prev = meta;
+  }
+  gpa->largeAllocs = meta;
+  return cu_Slice_some(meta->slice);
+}
+
+static cu_Slice_Optional cu_gpa_alloc(
+    void *self, size_t size, size_t alignment) {
+  cu_GPAllocator *gpa = (cu_GPAllocator *)self;
+  if (size == 0) {
+    return cu_Slice_none();
+  }
+  if (alignment == 0) {
+    alignment = 1;
+  }
+
+  size_t need = size > alignment ? size : alignment;
+  size_t obj_size = cu_next_pow2(need);
+
+  int idx = cu_gpa_index_from_size(obj_size);
+  if (idx < 0 || obj_size > gpa->bucketSize) {
+    return cu_gpa_alloc_large(gpa, size, alignment);
+  }
+  return cu_gpa_alloc_small(gpa, size, alignment, obj_size, idx);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Resize and free */
+/* -------------------------------------------------------------------------- */
+
+static cu_Slice_Optional cu_gpa_resize(
+    void *self, cu_Slice mem, size_t size, size_t alignment) {
+  cu_GPAllocator *gpa = (cu_GPAllocator *)self;
+  if (mem.ptr == NULL) {
+    return cu_gpa_alloc(self, size, alignment);
+  }
+  if (size == 0) {
+    cu_gpa_free(self, mem);
+    return cu_Slice_none();
+  }
+
+  size_t slot;
+  cu_GPAllocator_BucketHeader *bucket = cu_gpa_find_bucket(gpa, mem.ptr, &slot);
+  if (!bucket) {
+    cu_GPALargeAlloc *meta = cu_gpa_find_large(gpa, mem.ptr);
+    if (!meta) {
+      return cu_Slice_none();
+    }
+    cu_Slice_Optional resized = cu_Allocator_Resize(
+        gpa->backingAllocator, meta->slice, size, alignment);
+    if (cu_Slice_is_none(&resized)) {
+      return cu_Slice_none();
+    }
+    meta->slice = resized.value;
+    return resized;
+  }
+
+  if (size <= bucket->objects.objectSize &&
+      alignment <= bucket->objects.objectSize) {
+    return cu_Slice_some(cu_Slice_create(mem.ptr, size));
+  }
+
+  cu_Slice_Optional new_mem = cu_gpa_alloc(self, size, alignment);
+  if (cu_Slice_is_none(&new_mem)) {
+    return cu_Slice_none();
+  }
+  size_t copy = mem.length < size ? mem.length : size;
+  memmove(new_mem.value.ptr, mem.ptr, copy);
+  cu_gpa_free(self, mem);
+  return new_mem;
+}
+
+static void cu_gpa_free_small(
+    cu_GPAllocator *gpa, cu_GPAllocator_BucketHeader *bucket, size_t slot) {
+  cu_GPAllocator_UsedBits_clear(&bucket->objects.used, slot);
+  if (bucket->objects.usedCount > 0) {
+    bucket->objects.usedCount--;
+  }
+  CU_UNUSED(gpa);
+}
+
+static void cu_gpa_free_large(cu_GPAllocator *gpa, cu_GPALargeAlloc *meta) {
+  if (meta->prev) {
+    meta->prev->next = meta->next;
+  } else {
+    gpa->largeAllocs = meta->next;
+  }
+  if (meta->next) {
+    meta->next->prev = meta->prev;
+  }
+  cu_Allocator_Free(gpa->backingAllocator, meta->slice);
+  cu_Allocator_Free(
+      gpa->backingAllocator, cu_Slice_create(meta, sizeof(cu_GPALargeAlloc)));
+}
+
+static void cu_gpa_free(void *self, cu_Slice mem) {
+  cu_GPAllocator *gpa = (cu_GPAllocator *)self;
+  if (mem.ptr == NULL) {
+    return;
+  }
+  size_t slot;
+  cu_GPAllocator_BucketHeader *bucket = cu_gpa_find_bucket(gpa, mem.ptr, &slot);
+  if (bucket) {
+    cu_gpa_free_small(gpa, bucket, slot);
+    return;
+  }
+  cu_GPALargeAlloc *meta = cu_gpa_find_large(gpa, mem.ptr);
+  if (meta) {
+    cu_gpa_free_large(gpa, meta);
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* Public API */
+/* -------------------------------------------------------------------------- */
+
+cu_Allocator cu_Allocator_GPAllocator(
+    cu_GPAllocator *alloc, cu_GPAllocator_Config config) {
+  if (cu_Allocator_is_some(&config.backingAllocator)) {
+    alloc->backingAllocator = config.backingAllocator.value;
+  } else {
+    alloc->backingAllocator = cu_Allocator_CAllocator();
+  }
+  alloc->bucketSize =
+      config.bucketSize ? config.bucketSize : CU_GPA_BUCKET_SIZE;
+  for (int i = 0; i < CU_GPA_NUM_SMALL_BUCKETS; ++i) {
+    alloc->smallBuckets[i] = NULL;
+  }
+  alloc->largeAllocs = NULL;
+
+  cu_Allocator a;
+  a.self = alloc;
+  a.allocFn = cu_gpa_alloc;
+  a.resizeFn = cu_gpa_resize;
+  a.freeFn = cu_gpa_free;
+  return a;
+}
+
+static void cu_gpa_destroy_bucket(
+    cu_GPAllocator *gpa, cu_GPAllocator_BucketHeader *bucket) {
+  cu_Allocator_Free(gpa->backingAllocator,
+      cu_Slice_create(bucket, sizeof(*bucket) + bucket->objects.objectSize *
+                                                    bucket->objects.slotCount));
+}
+
+void cu_GPAllocator_destroy(cu_GPAllocator *alloc) {
+  for (int i = 0; i < CU_GPA_NUM_SMALL_BUCKETS; ++i) {
+    cu_GPAllocator_BucketHeader *b = alloc->smallBuckets[i];
+    while (b) {
+      cu_GPAllocator_BucketHeader *next = b->next;
+      cu_gpa_destroy_bucket(alloc, b);
+      b = next;
+    }
+    alloc->smallBuckets[i] = NULL;
+  }
+  cu_GPALargeAlloc *la = alloc->largeAllocs;
+  while (la) {
+    cu_GPALargeAlloc *next = la->next;
+    cu_gpa_free_large(alloc, la);
+    la = next;
+  }
+  alloc->largeAllocs = NULL;
+}

--- a/meson.build
+++ b/meson.build
@@ -12,6 +12,7 @@ sources = [
   'lib/object/optional.c',
   'lib/memory/allocator.c',
   'lib/memory/page.c',
+  'lib/memory/gpallocator.c',
   'lib/hash/hash.c',
   'lib/string/string.c',
 ]


### PR DESCRIPTION
## Summary
- refine general-purpose allocator naming
- implement next-power-of-two helper
- tweak example to use custom bucket size
- clean up GP allocator implementation
- allow custom backing allocator in GPA config
- use Optional type for GP allocator backing allocator

## Testing
- `python3 meson-1.8.2/meson.py setup --reconfigure build`
- `ninja -C build`
- `./build/cute_test`
- `valgrind --leak-check=full ./build/cute_test`


------
https://chatgpt.com/codex/tasks/task_e_686a1462cca883339540a889f9e81277