### PR TITLE
allocator: switch gpa to bitmap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@ build/
 out/
 meson-1.8.2/
 meson-1.8.2.tar.gz
+git-cliff-1.0.0/
+git-cliff-1.0.0-x86_64-unknown-linux-gnu.tar.gz
+
+# Ignore downloaded subprojects but keep wrap files
+subprojects/
+!subprojects/*.wrap

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,13 +36,17 @@ All notable changes to this project will be documented in this file. See [conven
 - changed changelog format again - ([87b6f41](https://git.schaub-dev.xyz/cppuniverse/libcute/commit/87b6f416f96f7d5fe2afc5b649d8648c626b41a9)) - Fabrice
 - formats the codebase, splits tests into individual tests, fixes bitset warnings - ([2009a07](https://git.schaub-dev.xyz/cppuniverse/libcute/commit/2009a07316e9a08f24c40d0e720dfb3772b7aa45)) - Fabrice
 
+- keep gtest wrap files when ignoring subprojects - Codex
+
 ### Tests
 
 - add gtest suite - ([bf83735](https://git.schaub-dev.xyz/cppuniverse/libcute/commit/bf83735d2a293626e755afb04c0a0a5e530aedbe)) - Fabrice
+- stress test large and small GP allocator allocations - Codex
 
 ### Allocator
 
 - use optional for gpa backing - ([c77ca60](https://git.schaub-dev.xyz/cppuniverse/libcute/commit/c77ca60622080cc2688454f5c331889297a7d2d8)) - Fabrice
+- gpa uses bitmap for variable bucket sizes - Fabrice
 
 ### Note
 

--- a/include/collection/bitmap.h
+++ b/include/collection/bitmap.h
@@ -4,21 +4,36 @@
 #include "object/optional.h"
 #include <stddef.h>
 
+/**
+ * @brief Dynamically allocated bitmap.
+ *
+ * The bitmap stores its bits on the heap using the provided allocator. Bits
+ * are referenced by index starting at zero. Out‑of‑range accesses are ignored
+ * to keep the API simple. The number of bits is specified during creation and
+ * can be queried with ::cu_Bitmap_size.
+ */
 typedef struct {
-  cu_Allocator backingAllocator; /**< allocator used for all bookkeeping */
-  size_t *bits;
-  size_t bitCount; /**< number of bits in the bitmap */
+  cu_Allocator backingAllocator; /**< allocator used for bookkeeping */
+  size_t *bits;                  /**< bit storage */
+  size_t bitCount;               /**< total bits contained */
 } cu_Bitmap;
 
 CU_OPTIONAL_DECL(cu_Bitmap, cu_Bitmap)
 
+/** Create a bitmap with the given number of bits. */
 cu_Bitmap_Optional cu_Bitmap_create(
     cu_Allocator backingAllocator, size_t bitCount);
+/** Release all memory owned by @p bitmap. */
 void cu_Bitmap_destroy(cu_Bitmap *bitmap);
+/** Query a single bit. */
 bool cu_Bitmap_get(const cu_Bitmap *bitmap, size_t index);
+/** Set a single bit. */
 void cu_Bitmap_set(cu_Bitmap *bitmap, size_t index);
+/** Clear a single bit. */
 void cu_Bitmap_clear(cu_Bitmap *bitmap, size_t index);
+/** Clear all bits in the bitmap. */
 void cu_Bitmap_clear_all(cu_Bitmap *bitmap);
+/** Number of bits held by the bitmap. */
 static inline size_t cu_Bitmap_size(const cu_Bitmap *bitmap) {
   return bitmap->bitCount;
 }

--- a/include/memory/gpallocator.h
+++ b/include/memory/gpallocator.h
@@ -2,7 +2,7 @@
 
 /** @file gpallocator.h General purpose allocator. */
 
-#include "collection/bitset.h"
+#include "collection/bitmap.h"
 #include "memory/allocator.h"
 #include <stdbool.h>
 #include <stddef.h>
@@ -11,17 +11,15 @@
 #define CU_GPA_NUM_SMALL_BUCKETS 16 /**< number of size classes */
 #define CU_GPA_CANARY 0x9232a6ff85dff10fULL /**< bucket canary value */
 
-CU_BITSET_DECL(cu_GPAllocator_UsedBits, CU_GPA_BUCKET_SIZE)
-
 struct cu_GPAllocator_BucketHeader;
 
 /** Object pool used by buckets to track slot usage. */
 struct cu_GPAllocator_ObjectPool {
-  cu_GPAllocator_UsedBits_BitSet used; /**< slot usage bitset */
-  unsigned char *data;                 /**< pointer to slot memory */
-  size_t objectSize;                   /**< size of each object */
-  size_t slotCount;                    /**< total slots */
-  size_t usedCount;                    /**< number of used slots */
+  cu_Bitmap used;      /**< slot usage bitmap */
+  unsigned char *data; /**< pointer to slot memory */
+  size_t objectSize;   /**< size of each object */
+  size_t slotCount;    /**< total slots */
+  size_t usedCount;    /**< number of used slots */
 };
 
 /** Metadata for a single bucket of small allocations. */

--- a/lib/collection/bitmap.c
+++ b/lib/collection/bitmap.c
@@ -27,8 +27,10 @@ cu_Bitmap_Optional cu_Bitmap_create(
 
 void cu_Bitmap_destroy(cu_Bitmap *bitmap) {
   if (bitmap->bits) {
+    size_t size =
+        (bitmap->bitCount + sizeof(size_t) * 8 - 1) / (sizeof(size_t) * 8);
     cu_Allocator_Free(bitmap->backingAllocator,
-        cu_Slice_create(bitmap->bits, bitmap->bitCount / 8));
+        cu_Slice_create(bitmap->bits, size * sizeof(size_t)));
     bitmap->bits = NULL;
     bitmap->bitCount = 0;
   }

--- a/meson.build
+++ b/meson.build
@@ -13,6 +13,7 @@ sources = [
   'lib/memory/allocator.c',
   'lib/memory/page.c',
   'lib/memory/gpallocator.c',
+  'lib/collection/bitmap.c',
   'lib/hash/hash.c',
   'lib/string/string.c',
 ]

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -6,6 +6,8 @@ test_files = [
   'test_optional.cpp',
   'test_string.cpp',
   'test_allocator.cpp',
+  'test_bitmap.cpp',
+  'test_gpa_large.cpp',
   'test_hash.cpp',
   'test_page_allocator.cpp',
 ]

--- a/tests/test_bitmap.cpp
+++ b/tests/test_bitmap.cpp
@@ -1,0 +1,21 @@
+#include <gtest/gtest.h>
+extern "C" {
+#include "collection/bitmap.h"
+#include "memory/allocator.h"
+}
+
+TEST(Bitmap, Basic) {
+  cu_Allocator alloc = cu_Allocator_CAllocator();
+  cu_Bitmap_Optional opt = cu_Bitmap_create(alloc, 128);
+  ASSERT_TRUE(cu_Bitmap_is_some(&opt));
+  cu_Bitmap map = opt.value;
+
+  EXPECT_EQ(cu_Bitmap_size(&map), 128u);
+  EXPECT_FALSE(cu_Bitmap_get(&map, 5));
+  cu_Bitmap_set(&map, 5);
+  EXPECT_TRUE(cu_Bitmap_get(&map, 5));
+  cu_Bitmap_clear(&map, 5);
+  EXPECT_FALSE(cu_Bitmap_get(&map, 5));
+
+  cu_Bitmap_destroy(&map);
+}

--- a/tests/test_gpa_large.cpp
+++ b/tests/test_gpa_large.cpp
@@ -1,0 +1,36 @@
+#include <gtest/gtest.h>
+#include <vector>
+extern "C" {
+#include "memory/allocator.h"
+#include "memory/gpallocator.h"
+}
+
+TEST(Allocator, GPALargeAllocFree) {
+  cu_GPAllocator gpa;
+  cu_GPAllocator_Config cfg = {0};
+  cfg.backingAllocator = cu_Allocator_none();
+  cu_Allocator alloc = cu_Allocator_GPAllocator(&gpa, cfg);
+
+  const size_t big = 100 * 1024 * 1024; // 100 MiB
+  cu_Slice_Optional mem = cu_Allocator_Alloc(alloc, big, 16);
+  ASSERT_TRUE(cu_Slice_is_some(&mem));
+  memset(mem.value.ptr, 0xCD, mem.value.length);
+  cu_Allocator_Free(alloc, mem.value);
+
+  const size_t small = 4096; // 4 KiB blocks
+  const size_t total = 100 * 1024 * 1024;
+  const size_t count = total / small;
+  std::vector<cu_Slice> blocks;
+  blocks.reserve(count);
+  for (size_t i = 0; i < count; ++i) {
+    cu_Slice_Optional s = cu_Allocator_Alloc(alloc, small, 16);
+    ASSERT_TRUE(cu_Slice_is_some(&s));
+    memset(s.value.ptr, 0xEF, s.value.length);
+    blocks.push_back(s.value);
+  }
+  for (cu_Slice s : blocks) {
+    cu_Allocator_Free(alloc, s);
+  }
+
+  cu_GPAllocator_destroy(&gpa);
+}


### PR DESCRIPTION
## Summary
- allow gpa buckets to use dynamically sized bitmaps
- fully document the bitmap API
- add tests for bitmap and large GPA allocations
- track gtest wrap file and extend GPA stress test

## Testing
- `python3 meson-1.8.2/meson.py test -C build --print-errorlogs`


------
https://chatgpt.com/codex/tasks/task_e_686a3823428c8333ae75550709918ca3