### PR TITLE
Improve vector docs and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file. See [conven
 - clarify bitset and bitmap - ([c212ee4](https://git.schaub-dev.xyz/cppuniverse/libcute/commit/c212ee43b27021c33c70cf24a19d865059b37711)) - Fabrice
 - adds changelog - ([0bc1278](https://git.schaub-dev.xyz/cppuniverse/libcute/commit/0bc1278bbbce8395fe775b69a17c5577cae5f2db)) - Fabrice
 - ticked of bitmap in readme - ([656315c](https://git.schaub-dev.xyz/cppuniverse/libcute/commit/656315cda577df40dc79e4d1c64659e52c9f2d09)) - Fabrice
+- document vector type and functions
 
 ### Features
 
@@ -42,6 +43,7 @@ All notable changes to this project will be documented in this file. See [conven
 
 - add gtest suite - ([bf83735](https://git.schaub-dev.xyz/cppuniverse/libcute/commit/bf83735d2a293626e755afb04c0a0a5e530aedbe)) - Fabrice
 - extend gpa stress test - ([f8d3fee](https://git.schaub-dev.xyz/cppuniverse/libcute/commit/f8d3feea274351cf999d84d6c93a115619072d4f)) - Fabrice
+- split vector tests and cover pop_back
 
 ### Allocator
 

--- a/include/collection/vector.h
+++ b/include/collection/vector.h
@@ -8,38 +8,54 @@
 #include "utility.h"
 #include <stddef.h>
 
+/**
+ * @brief Growable array of elements.
+ *
+ * The vector manages a contiguous memory block whose layout is described by
+ * ::cu_Layout. It automatically resizes when elements are inserted.
+ */
 typedef struct {
-  cu_Slice_Optional data;
-  size_t length;
-  size_t capacity;
-  cu_Layout layout;
-  cu_Allocator allocator;
+  cu_Slice_Optional data; /**< memory backing the vector */
+  size_t length;          /**< number of valid elements */
+  size_t capacity;        /**< allocated element capacity */
+  cu_Layout layout;       /**< layout of each element */
+  cu_Allocator allocator; /**< allocator used for storage */
 } cu_Vector;
 
+/**
+ * @brief Error codes returned by vector operations.
+ */
 typedef enum {
-  CU_VECTOR_ERROR_NONE = 0,
-  CU_VECTOR_ERROR_OOM,
-  CU_VECTOR_ERROR_INVALID_LAYOUT,
-  CU_VECTOR_ERROR_INVALID,
-  CU_VECTOR_ERROR_OOB,
+  CU_VECTOR_ERROR_NONE = 0,    /**< success */
+  CU_VECTOR_ERROR_OOM,         /**< out of memory */
+  CU_VECTOR_ERROR_INVALID_LAYOUT, /**< invalid element layout */
+  CU_VECTOR_ERROR_INVALID,     /**< invalid argument */
+  CU_VECTOR_ERROR_OOB,         /**< out of bounds access */
 } cu_Vector_Error;
 
 CU_RESULT_DECL(cu_Vector, cu_Vector, cu_Vector_Error)
 CU_OPTIONAL_DECL(cu_Vector_Error, cu_Vector_Error)
 
+/** Create a new vector. */
 cu_Vector_Result cu_Vector_create(
     cu_Allocator allocator, cu_Layout layout, Size_Optional initial_capacity);
+/** Adjust the capacity of the vector. */
 cu_Vector_Error_Optional cu_Vector_resize(cu_Vector *vector, size_t capacity);
+/** Release resources owned by @p vector. */
 void cu_Vector_destroy(cu_Vector *vector);
 
+/** Current number of elements held by the vector. */
 static inline size_t cu_Vector_size(const cu_Vector *vector) {
   CU_IF_NULL(vector) { return 0; }
   return vector->length;
 }
+/** Allocated capacity of the vector. */
 static inline size_t cu_Vector_capacity(const cu_Vector *vector) {
   CU_IF_NULL(vector) { return 0; }
   return vector->capacity;
 }
 
+/** Append a new element to the end of the vector. */
 cu_Vector_Error_Optional cu_Vector_push_back(cu_Vector *vector, void *elem);
+/** Remove the last element and copy it into @p out_elem. */
 cu_Vector_Error_Optional cu_Vector_pop_back(cu_Vector *vector, void *out_elem);

--- a/tests/test_vector.cpp
+++ b/tests/test_vector.cpp
@@ -6,40 +6,94 @@ extern "C" {
 }
 #include <gtest/gtest.h>
 
-TEST(Vector, CreateAndResize) {
-  cu_PageAllocator page_allocator;
-  cu_Allocator page_alloc = cu_Allocator_PageAllocator(&page_allocator);
+static cu_Allocator create_allocator(cu_GPAllocator *gpa, cu_PageAllocator *page) {
+  cu_Allocator page_alloc = cu_Allocator_PageAllocator(page);
+  cu_GPAllocator_Config cfg = {};
+  cfg.bucketSize = CU_GPA_BUCKET_SIZE;
+  cfg.backingAllocator = cu_Allocator_some(page_alloc);
+  return cu_Allocator_GPAllocator(gpa, cfg);
+}
+
+TEST(Vector, Create) {
+  cu_PageAllocator page;
   cu_GPAllocator gpa;
-  cu_GPAllocator_Config gpa_config = {};
-  gpa_config.bucketSize = CU_GPA_BUCKET_SIZE;
-  gpa_config.backingAllocator = cu_Allocator_some(page_alloc);
-  cu_Allocator gpa_alloc = cu_Allocator_GPAllocator(&gpa, gpa_config);
+  cu_Allocator alloc = create_allocator(&gpa, &page);
 
   cu_Layout layout = CU_LAYOUT(int);
-  cu_Vector_Result result = cu_Vector_create(gpa_alloc, layout, Size_some(10));
-  ASSERT_TRUE(cu_Vector_result_is_ok(&result));
+  cu_Vector_Result res = cu_Vector_create(alloc, layout, Size_some(10));
+  ASSERT_TRUE(cu_Vector_result_is_ok(&res));
+  cu_Vector vec = cu_Vector_result_unwrap(&res);
+  EXPECT_EQ(vec.length, 0u);
+  EXPECT_EQ(vec.capacity, 10u);
 
-  cu_Vector vector = cu_Vector_result_unwrap(&result);
-  ASSERT_EQ(vector.length, 0);
-  ASSERT_EQ(vector.capacity, 10);
+  cu_Vector_destroy(&vec);
+  cu_GPAllocator_destroy(&gpa);
+}
 
-  cu_Vector_Error_Optional resize_result = cu_Vector_resize(&vector, 20);
-  ASSERT_TRUE(cu_Vector_Error_is_none(&resize_result));
-  ASSERT_EQ(cu_Vector_capacity(&vector), 20);
-  ASSERT_EQ(cu_Vector_size(&vector), 0);
+TEST(Vector, Resize) {
+  cu_PageAllocator page;
+  cu_GPAllocator gpa;
+  cu_Allocator alloc = create_allocator(&gpa, &page);
 
-  resize_result = cu_Vector_resize(&vector, 5);
-  ASSERT_TRUE(cu_Vector_Error_is_none(&resize_result));
-  ASSERT_EQ(cu_Vector_capacity(&vector), 20);
-  ASSERT_EQ(cu_Vector_size(&vector), 0);
+  cu_Layout layout = CU_LAYOUT(int);
+  cu_Vector_Result res = cu_Vector_create(alloc, layout, Size_some(10));
+  ASSERT_TRUE(cu_Vector_result_is_ok(&res));
+  cu_Vector vector = cu_Vector_result_unwrap(&res);
 
-  int value = 42;
-  resize_result = cu_Vector_push_back(&vector, &value);
-  ASSERT_TRUE(cu_Vector_Error_is_none(&resize_result));
-  ASSERT_EQ(cu_Vector_size(&vector), 1);
-  ASSERT_EQ(*(int *)((unsigned char *)vector.data.value.ptr +
-                     0 * vector.layout.elem_size),
-      42);
+  cu_Vector_Error_Optional err = cu_Vector_resize(&vector, 20);
+  ASSERT_TRUE(cu_Vector_Error_is_none(&err));
+  EXPECT_EQ(cu_Vector_capacity(&vector), 20u);
+
+  err = cu_Vector_resize(&vector, 5);
+  ASSERT_TRUE(cu_Vector_Error_is_none(&err));
+  EXPECT_EQ(cu_Vector_capacity(&vector), 20u);
 
   cu_Vector_destroy(&vector);
+  cu_GPAllocator_destroy(&gpa);
+}
+
+TEST(Vector, PushBack) {
+  cu_PageAllocator page;
+  cu_GPAllocator gpa;
+  cu_Allocator alloc = create_allocator(&gpa, &page);
+
+  cu_Vector_Result res = cu_Vector_create(alloc, CU_LAYOUT(int), Size_some(0));
+  ASSERT_TRUE(cu_Vector_result_is_ok(&res));
+  cu_Vector vector = cu_Vector_result_unwrap(&res);
+
+  int v = 42;
+  cu_Vector_Error_Optional err = cu_Vector_push_back(&vector, &v);
+  ASSERT_TRUE(cu_Vector_Error_is_none(&err));
+  EXPECT_EQ(cu_Vector_size(&vector), 1u);
+  EXPECT_EQ(*(int *)((unsigned char *)vector.data.value.ptr), 42);
+
+  cu_Vector_destroy(&vector);
+  cu_GPAllocator_destroy(&gpa);
+}
+
+TEST(Vector, PopBack) {
+  cu_PageAllocator page;
+  cu_GPAllocator gpa;
+  cu_Allocator alloc = create_allocator(&gpa, &page);
+
+  cu_Vector_Result res = cu_Vector_create(alloc, CU_LAYOUT(int), Size_some(0));
+  ASSERT_TRUE(cu_Vector_result_is_ok(&res));
+  cu_Vector vector = cu_Vector_result_unwrap(&res);
+
+  int a = 1, b = 2, out = 0;
+  cu_Vector_push_back(&vector, &a);
+  cu_Vector_push_back(&vector, &b);
+
+  cu_Vector_Error_Optional err = cu_Vector_pop_back(&vector, &out);
+  ASSERT_TRUE(cu_Vector_Error_is_none(&err));
+  EXPECT_EQ(out, 2);
+  EXPECT_EQ(cu_Vector_size(&vector), 1u);
+
+  err = cu_Vector_pop_back(&vector, &out);
+  ASSERT_TRUE(cu_Vector_Error_is_none(&err));
+  EXPECT_EQ(out, 1);
+  EXPECT_EQ(cu_Vector_size(&vector), 0u);
+
+  cu_Vector_destroy(&vector);
+  cu_GPAllocator_destroy(&gpa);
 }


### PR DESCRIPTION
## Summary
- document `cu_Vector` and related functions
- refactor vector tests into smaller cases
- add pop_back coverage

## Testing
- `meson setup build -Dtests=enabled`
- `ninja -C build`
- `meson test -C build`


------
https://chatgpt.com/codex/tasks/task_e_686a9727a0388333a9006ffcb1aadbee