### PR TITLE
Implement ring buffer container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable changes to this project will be documented in this file. See [conven
 - adds bitset, starts implementing gpa, fixes macros - ([931d391](https://git.schaub-dev.xyz/cppuniverse/libcute/commit/931d391a6551b651af0f4170bf7e3d2b792b5440)) - Fabrice
 - adds bitmap type - ([d0b722c](https://git.schaub-dev.xyz/cppuniverse/libcute/commit/d0b722cc539b83a4dd722960faba92a604548b6f)) - Fabrice
 - adds faulty vector type - ([05563aa](https://git.schaub-dev.xyz/cppuniverse/libcute/commit/05563aa26c7bf347d5cbd4f4d204d58b81be650f)) - Fabrice
+- implement ring buffer container
 - copy whole arrays - ([9e54a5f](https://git.schaub-dev.xyz/cppuniverse/libcute/commit/9e54a5f1b2b23f8c57c0d661cbcd157b413d2c35)) - Fabrice
 
 ### Refactoring

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ collection-features:
       Bitsets keep their storage inline and provide fast, stack-friendly access.
       Bitmaps allocate their storage on the heap and are used for larger dynamic sets.
 - [ ] linked and doubly linked
-- [ ] ring buffer
+- [x] ring buffer
 
 method-features:
 

--- a/include/collection/ring_buffer.h
+++ b/include/collection/ring_buffer.h
@@ -1,0 +1,67 @@
+#pragma once
+
+/** @file ring_buffer.h Circular buffer container. */
+
+#include "macro.h"
+#include "memory/allocator.h"
+#include "object/optional.h"
+#include "object/result.h"
+#include "object/slice.h"
+#include "utility.h"
+#include <stdbool.h>
+#include <stddef.h>
+
+/**
+ * @brief Ring buffer storing elements in FIFO order.
+ */
+typedef struct {
+  cu_Slice_Optional data; /**< element storage */
+  size_t capacity;        /**< maximum elements */
+  size_t head;            /**< index of first element */
+  size_t length;          /**< number of stored elements */
+  cu_Layout layout;       /**< element layout */
+  cu_Allocator allocator; /**< backing allocator */
+} cu_RingBuffer;
+
+/** Error codes returned by ring buffer operations. */
+typedef enum {
+  CU_RINGBUFFER_ERROR_NONE = 0,
+  CU_RINGBUFFER_ERROR_OOM,
+  CU_RINGBUFFER_ERROR_INVALID_LAYOUT,
+  CU_RINGBUFFER_ERROR_INVALID,
+  CU_RINGBUFFER_ERROR_FULL,
+  CU_RINGBUFFER_ERROR_EMPTY,
+} cu_RingBuffer_Error;
+
+CU_RESULT_DECL(cu_RingBuffer, cu_RingBuffer, cu_RingBuffer_Error)
+CU_OPTIONAL_DECL(cu_RingBuffer_Error, cu_RingBuffer_Error)
+
+cu_RingBuffer_Result cu_RingBuffer_create(
+    cu_Allocator allocator, cu_Layout layout, size_t capacity);
+
+void cu_RingBuffer_destroy(cu_RingBuffer *rb);
+
+static inline size_t cu_RingBuffer_size(const cu_RingBuffer *rb) {
+  CU_IF_NULL(rb) { return 0; }
+  return rb->length;
+}
+
+static inline size_t cu_RingBuffer_capacity(const cu_RingBuffer *rb) {
+  CU_IF_NULL(rb) { return 0; }
+  return rb->capacity;
+}
+
+static inline bool cu_RingBuffer_is_empty(const cu_RingBuffer *rb) {
+  CU_IF_NULL(rb) { return true; }
+  return rb->length == 0;
+}
+
+static inline bool cu_RingBuffer_is_full(const cu_RingBuffer *rb) {
+  CU_IF_NULL(rb) { return false; }
+  return rb->length == rb->capacity && rb->capacity > 0;
+}
+
+cu_RingBuffer_Error_Optional cu_RingBuffer_push(cu_RingBuffer *rb, void *elem);
+
+cu_RingBuffer_Error_Optional cu_RingBuffer_pop(
+    cu_RingBuffer *rb, void *out_elem);

--- a/include/cute.h
+++ b/include/cute.h
@@ -12,8 +12,9 @@ extern "C" {
 
 #include "collection/bitmap.h"
 #include "collection/bitset.h"
-#include "collection/vector.h"
 #include "collection/hashmap.h"
+#include "collection/ring_buffer.h"
+#include "collection/vector.h"
 
 #include "hash/hash.h"
 #include "macro.h"

--- a/lib/collection/ring_buffer.c
+++ b/lib/collection/ring_buffer.c
@@ -1,0 +1,85 @@
+#include "collection/ring_buffer.h"
+#include "utility.h"
+#include <string.h>
+
+CU_RESULT_IMPL(cu_RingBuffer, cu_RingBuffer, cu_RingBuffer_Error)
+CU_OPTIONAL_IMPL(cu_RingBuffer_Error, cu_RingBuffer_Error)
+
+cu_RingBuffer_Result cu_RingBuffer_create(
+    cu_Allocator allocator, cu_Layout layout, size_t capacity) {
+  CU_LAYOUT_CHECK(layout) {
+    return cu_RingBuffer_result_error(CU_RINGBUFFER_ERROR_INVALID_LAYOUT);
+  }
+
+  cu_Slice_Optional data = cu_Slice_Optional_none();
+  if (capacity > 0) {
+    data = cu_Allocator_Alloc(
+        allocator, capacity * layout.elem_size, layout.alignment);
+    if (cu_Slice_Optional_is_none(&data)) {
+      return cu_RingBuffer_result_error(CU_RINGBUFFER_ERROR_OOM);
+    }
+  }
+
+  cu_RingBuffer rb;
+  rb.data = data;
+  rb.capacity = capacity;
+  rb.head = 0;
+  rb.length = 0;
+  rb.layout = layout;
+  rb.allocator = allocator;
+
+  return cu_RingBuffer_result_ok(rb);
+}
+
+void cu_RingBuffer_destroy(cu_RingBuffer *rb) {
+  if (!rb) {
+    return;
+  }
+  if (cu_Slice_Optional_is_some(&rb->data)) {
+    cu_Allocator_Free(rb->allocator, cu_Slice_create(rb->data.value.ptr,
+                                         rb->capacity * rb->layout.elem_size));
+    rb->data = cu_Slice_Optional_none();
+  }
+  rb->capacity = 0;
+  rb->head = 0;
+  rb->length = 0;
+}
+
+cu_RingBuffer_Error_Optional cu_RingBuffer_push(cu_RingBuffer *rb, void *elem) {
+  CU_IF_NULL(rb) {
+    return cu_RingBuffer_Error_Optional_some(CU_RINGBUFFER_ERROR_INVALID);
+  }
+  CU_LAYOUT_CHECK(rb->layout) {
+    return cu_RingBuffer_Error_Optional_some(
+        CU_RINGBUFFER_ERROR_INVALID_LAYOUT);
+  }
+  if (cu_RingBuffer_is_full(rb)) {
+    return cu_RingBuffer_Error_Optional_some(CU_RINGBUFFER_ERROR_FULL);
+  }
+  size_t tail = (rb->head + rb->length) % rb->capacity;
+  void *dest =
+      (unsigned char *)rb->data.value.ptr + tail * rb->layout.elem_size;
+  memcpy(dest, elem, rb->layout.elem_size);
+  rb->length++;
+  return cu_RingBuffer_Error_Optional_none();
+}
+
+cu_RingBuffer_Error_Optional cu_RingBuffer_pop(
+    cu_RingBuffer *rb, void *out_elem) {
+  CU_IF_NULL(rb) {
+    return cu_RingBuffer_Error_Optional_some(CU_RINGBUFFER_ERROR_INVALID);
+  }
+  CU_LAYOUT_CHECK(rb->layout) {
+    return cu_RingBuffer_Error_Optional_some(
+        CU_RINGBUFFER_ERROR_INVALID_LAYOUT);
+  }
+  if (cu_RingBuffer_is_empty(rb)) {
+    return cu_RingBuffer_Error_Optional_some(CU_RINGBUFFER_ERROR_EMPTY);
+  }
+  void *src =
+      (unsigned char *)rb->data.value.ptr + rb->head * rb->layout.elem_size;
+  memcpy(out_elem, src, rb->layout.elem_size);
+  rb->head = (rb->head + 1) % rb->capacity;
+  rb->length--;
+  return cu_RingBuffer_Error_Optional_none();
+}

--- a/meson.build
+++ b/meson.build
@@ -16,6 +16,7 @@ sources = [
   'lib/collection/bitmap.c',
   'lib/hash/hash.c',
   'lib/string/string.c',
+  'lib/collection/ring_buffer.c',
   'lib/collection/vector.c',
   'lib/collection/hashmap.c',
 ]

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -11,6 +11,7 @@ test_files = [
   'test_hash.cpp',
   'test_hashmap.cpp',
   'test_page_allocator.cpp',
+  'test_ring_buffer.cpp',
   'test_vector.cpp',
 ]
 

--- a/tests/test_ring_buffer.cpp
+++ b/tests/test_ring_buffer.cpp
@@ -1,0 +1,44 @@
+extern "C" {
+#include "collection/ring_buffer.h"
+#include "memory/allocator.h"
+#include "memory/gpallocator.h"
+#include "memory/page.h"
+}
+#include <gtest/gtest.h>
+
+static cu_Allocator create_allocator(
+    cu_GPAllocator *gpa, cu_PageAllocator *page) {
+  cu_Allocator page_alloc = cu_Allocator_PageAllocator(page);
+  cu_GPAllocator_Config cfg = {};
+  cfg.bucketSize = CU_GPA_BUCKET_SIZE;
+  cfg.backingAllocator = cu_Allocator_Optional_some(page_alloc);
+  return cu_Allocator_GPAllocator(gpa, cfg);
+}
+
+TEST(RingBuffer, PushPop) {
+  cu_PageAllocator page;
+  cu_GPAllocator gpa;
+  cu_Allocator alloc = create_allocator(&gpa, &page);
+
+  cu_RingBuffer_Result res = cu_RingBuffer_create(alloc, CU_LAYOUT(int), 4);
+  ASSERT_TRUE(cu_RingBuffer_result_is_ok(&res));
+  cu_RingBuffer rb = cu_RingBuffer_result_unwrap(&res);
+
+  for (int i = 0; i < 4; ++i) {
+    int v = i;
+    cu_RingBuffer_Error_Optional err = cu_RingBuffer_push(&rb, &v);
+    ASSERT_TRUE(cu_RingBuffer_Error_Optional_is_none(&err));
+  }
+  ASSERT_TRUE(cu_RingBuffer_is_full(&rb));
+
+  for (int i = 0; i < 4; ++i) {
+    int out = 0;
+    cu_RingBuffer_Error_Optional err = cu_RingBuffer_pop(&rb, &out);
+    ASSERT_TRUE(cu_RingBuffer_Error_Optional_is_none(&err));
+    EXPECT_EQ(out, i);
+  }
+  EXPECT_TRUE(cu_RingBuffer_is_empty(&rb));
+
+  cu_RingBuffer_destroy(&rb);
+  cu_GPAllocator_destroy(&gpa);
+}


### PR DESCRIPTION
## Summary
- add missing ring buffer implementation and tests
- integrate ring buffer in build system and umbrella header
- mark ring buffer as done in README
- update changelog

## Testing
- `python3 meson-1.8.2/meson.py setup build -Dtests=enabled`
- `ninja -C build`
- `meson test -C build --print-errorlogs`


------
https://chatgpt.com/codex/tasks/task_e_686fb718ef3883338999fcbf128805fd