### PR TITLE
Add slab allocator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ All notable changes to this project will be documented in this file. See [conven
 
 - use optional for gpa backing - ([c77ca60](https://git.schaub-dev.xyz/cppuniverse/libcute/commit/c77ca60622080cc2688454f5c331889297a7d2d8)) - Fabrice
 - optimize small bucket performance - ([fc40724](https://git.schaub-dev.xyz/cppuniverse/libcute/commit/fc407241090ec0a39ba98901d0786ef3609b1b56)) - Fabrice
+- add slab allocator
 
 ### Merge
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ memory-features:
 - [x] Page Allocator
 - [x] C Allocator
 - [x] GP Allocator
-- [ ] Slab Allocator
+- [x] Slab Allocator
 - [ ] Arena Allocator
 - [ ] Fixed Allocator
 

--- a/include/cute.h
+++ b/include/cute.h
@@ -8,6 +8,7 @@ extern "C" {
 
 #include "memory/allocator.h"
 #include "memory/gpallocator.h"
+#include "memory/slab.h"
 #include "memory/page.h"
 
 #include "collection/bitmap.h"

--- a/include/memory/slab.h
+++ b/include/memory/slab.h
@@ -1,0 +1,31 @@
+#pragma once
+
+/** @file slab.h Simple slab allocator. */
+
+#include "memory/allocator.h"
+#include <stddef.h>
+
+#define CU_SLAB_DEFAULT_SIZE 4096 /**< default slab size */
+
+struct cu_SlabAllocator_Slab;
+
+/** Runtime state for the slab allocator. */
+typedef struct {
+  cu_Allocator backingAllocator;         /**< allocator used for slabs */
+  struct cu_SlabAllocator_Slab *slabs;   /**< list of allocated slabs */
+  struct cu_SlabAllocator_Slab *current; /**< slab used for new allocations */
+  size_t slabSize;                       /**< bytes per slab */
+} cu_SlabAllocator;
+
+/** Configuration for creating a slab allocator. */
+typedef struct {
+  size_t slabSize;                        /**< desired slab size */
+  cu_Allocator_Optional backingAllocator; /**< custom backing allocator */
+} cu_SlabAllocator_Config;
+
+/** Create a slab allocator using the given configuration. */
+cu_Allocator cu_Allocator_SlabAllocator(
+    cu_SlabAllocator *alloc, cu_SlabAllocator_Config cfg);
+
+/** Release all memory owned by the allocator. */
+void cu_SlabAllocator_destroy(cu_SlabAllocator *alloc);

--- a/lib/memory/slab.c
+++ b/lib/memory/slab.c
@@ -1,0 +1,125 @@
+#include "memory/slab.h"
+#include "macro.h"
+#include "object/slice.h"
+#include <string.h>
+
+struct cu_SlabAllocator_Slab {
+  struct cu_SlabAllocator_Slab *next;
+  size_t offset;
+  size_t capacity;
+  unsigned char data[];
+};
+
+static cu_Slice_Optional cu_slab_alloc(
+    void *self, size_t size, size_t alignment);
+static cu_Slice_Optional cu_slab_resize(
+    void *self, cu_Slice mem, size_t size, size_t alignment);
+static void cu_slab_free(void *self, cu_Slice mem);
+
+static struct cu_SlabAllocator_Slab *cu_create_slab(
+    cu_SlabAllocator *alloc, size_t capacity) {
+  size_t total = sizeof(struct cu_SlabAllocator_Slab) + capacity;
+  cu_Slice_Optional mem =
+      cu_Allocator_Alloc(alloc->backingAllocator, total, sizeof(void *));
+  if (cu_Slice_Optional_is_none(&mem)) {
+    return NULL;
+  }
+  struct cu_SlabAllocator_Slab *slab =
+      (struct cu_SlabAllocator_Slab *)mem.value.ptr;
+  slab->next = NULL;
+  slab->offset = 0;
+  slab->capacity = capacity;
+  return slab;
+}
+
+static cu_Slice_Optional cu_slab_alloc(
+    void *self, size_t size, size_t alignment) {
+  cu_SlabAllocator *alloc = (cu_SlabAllocator *)self;
+  if (size == 0) {
+    return cu_Slice_Optional_none();
+  }
+  if (alignment == 0) {
+    alignment = 1;
+  }
+
+  struct cu_SlabAllocator_Slab *slab = alloc->current;
+  size_t aligned = 0;
+  if (slab) {
+    aligned = CU_ALIGN_UP(slab->offset, alignment);
+  }
+  if (!slab || aligned + size > slab->capacity) {
+    size_t cap = size > alloc->slabSize ? size : alloc->slabSize;
+    slab = cu_create_slab(alloc, cap);
+    if (!slab) {
+      return cu_Slice_Optional_none();
+    }
+    if (alloc->current) {
+      alloc->current->next = slab;
+    } else {
+      alloc->slabs = slab;
+    }
+    alloc->current = slab;
+    aligned = CU_ALIGN_UP(slab->offset, alignment);
+  }
+
+  void *ptr = slab->data + aligned;
+  slab->offset = aligned + size;
+  return cu_Slice_Optional_some(cu_Slice_create(ptr, size));
+}
+
+static cu_Slice_Optional cu_slab_resize(
+    void *self, cu_Slice mem, size_t size, size_t alignment) {
+  if (mem.ptr == NULL) {
+    return cu_slab_alloc(self, size, alignment);
+  }
+  if (size == 0) {
+    cu_slab_free(self, mem);
+    return cu_Slice_Optional_none();
+  }
+  if (size <= mem.length) {
+    return cu_Slice_Optional_some(cu_Slice_create(mem.ptr, size));
+  }
+  cu_Slice_Optional new_mem = cu_slab_alloc(self, size, alignment);
+  if (cu_Slice_Optional_is_none(&new_mem)) {
+    return cu_Slice_Optional_none();
+  }
+  memcpy(new_mem.value.ptr, mem.ptr, mem.length < size ? mem.length : size);
+  return new_mem;
+}
+
+static void cu_slab_free(void *self, cu_Slice mem) {
+  CU_UNUSED(self);
+  CU_UNUSED(mem);
+  /* individual frees are ignored */
+}
+
+cu_Allocator cu_Allocator_SlabAllocator(
+    cu_SlabAllocator *alloc, cu_SlabAllocator_Config cfg) {
+  if (cu_Allocator_Optional_is_some(&cfg.backingAllocator)) {
+    alloc->backingAllocator = cfg.backingAllocator.value;
+  } else {
+    alloc->backingAllocator = cu_Allocator_CAllocator();
+  }
+  alloc->slabs = NULL;
+  alloc->current = NULL;
+  alloc->slabSize = cfg.slabSize ? cfg.slabSize : CU_SLAB_DEFAULT_SIZE;
+
+  cu_Allocator a;
+  a.self = alloc;
+  a.allocFn = cu_slab_alloc;
+  a.resizeFn = cu_slab_resize;
+  a.freeFn = cu_slab_free;
+  return a;
+}
+
+void cu_SlabAllocator_destroy(cu_SlabAllocator *alloc) {
+  struct cu_SlabAllocator_Slab *slab = alloc->slabs;
+  while (slab) {
+    struct cu_SlabAllocator_Slab *next = slab->next;
+    cu_Allocator_Free(alloc->backingAllocator,
+        cu_Slice_create(slab, sizeof(*slab) + slab->capacity));
+    slab = next;
+  }
+  alloc->slabs = NULL;
+  alloc->current = NULL;
+}

--- a/meson.build
+++ b/meson.build
@@ -13,6 +13,7 @@ sources = [
   'lib/memory/allocator.c',
   'lib/memory/page.c',
   'lib/memory/gpallocator.c',
+  'lib/memory/slab.c',
   'lib/collection/bitmap.c',
   'lib/hash/hash.c',
   'lib/string/string.c',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -11,6 +11,7 @@ test_files = [
   'test_hash.cpp',
   'test_hashmap.cpp',
   'test_page_allocator.cpp',
+  'test_slab_allocator.cpp',
   'test_ring_buffer.cpp',
   'test_vector.cpp',
   'test_fmt.cpp',

--- a/tests/test_slab_allocator.cpp
+++ b/tests/test_slab_allocator.cpp
@@ -1,0 +1,64 @@
+#include <gtest/gtest.h>
+#include <string.h>
+extern "C" {
+#include "memory/slab.h"
+}
+
+TEST(SlabAllocator, Basic) {
+  cu_SlabAllocator slab;
+  cu_SlabAllocator_Config cfg = {0};
+  cfg.slabSize = 64;
+  cfg.backingAllocator = cu_Allocator_Optional_none();
+  cu_Allocator alloc = cu_Allocator_SlabAllocator(&slab, cfg);
+
+  cu_Slice_Optional a = cu_Allocator_Alloc(alloc, 16, 8);
+  ASSERT_TRUE(cu_Slice_Optional_is_some(&a));
+  cu_Slice_Optional b = cu_Allocator_Alloc(alloc, 16, 8);
+  ASSERT_TRUE(cu_Slice_Optional_is_some(&b));
+  EXPECT_NE(a.value.ptr, b.value.ptr);
+
+  cu_SlabAllocator_destroy(&slab);
+}
+
+TEST(SlabAllocator, BigAllocation) {
+  cu_SlabAllocator slab;
+  cu_SlabAllocator_Config cfg = {0};
+  cfg.slabSize = 64;
+  cu_Allocator alloc = cu_Allocator_SlabAllocator(&slab, cfg);
+
+  cu_Slice_Optional big = cu_Allocator_Alloc(alloc, 256, 8);
+  ASSERT_TRUE(cu_Slice_Optional_is_some(&big));
+
+  cu_SlabAllocator_destroy(&slab);
+}
+
+TEST(SlabAllocator, Resize) {
+  cu_SlabAllocator slab;
+  cu_SlabAllocator_Config cfg = {0};
+  cfg.slabSize = 64;
+  cu_Allocator alloc = cu_Allocator_SlabAllocator(&slab, cfg);
+
+  cu_Slice_Optional mem = cu_Allocator_Alloc(alloc, 16, 8);
+  ASSERT_TRUE(cu_Slice_Optional_is_some(&mem));
+  memset(mem.value.ptr, 0xAA, mem.value.length);
+
+  cu_Slice_Optional resized = cu_Allocator_Resize(alloc, mem.value, 128, 8);
+  ASSERT_TRUE(cu_Slice_Optional_is_some(&resized));
+  EXPECT_EQ(((unsigned char *)resized.value.ptr)[0], 0xAA);
+
+  cu_SlabAllocator_destroy(&slab);
+}
+
+TEST(SlabAllocator, ManyAllocations) {
+  cu_SlabAllocator slab;
+  cu_SlabAllocator_Config cfg = {0};
+  cfg.slabSize = 32;
+  cu_Allocator alloc = cu_Allocator_SlabAllocator(&slab, cfg);
+
+  for (int i = 0; i < 1000; ++i) {
+    cu_Slice_Optional s = cu_Allocator_Alloc(alloc, 8, 4);
+    ASSERT_TRUE(cu_Slice_Optional_is_some(&s));
+  }
+
+  cu_SlabAllocator_destroy(&slab);
+}


### PR DESCRIPTION
## Summary
- implement simple slab allocator with configurable slab size
- hook the allocator into the build and umbrella header
- add unit tests
- document feature in README and changelog

## Testing
- `python3 meson-1.8.2/meson.py setup build -Dtests=enabled`
- `ninja -C build`
- `meson test -C build`


------
https://chatgpt.com/codex/tasks/task_e_687920483924833391e6d9b5bb2e7d32