### PR TITLE
Implement list and dlist insertion helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Changelog
+#Changelog
 
 All notable changes to this project will be documented in this file. See [conventional commits](https://www.conventionalcommits.org/) for commit guidelines.
 
@@ -67,6 +67,8 @@ All notable changes to this project will be documented in this file. See [conven
 ### Collection
 
 - add ring buffer container - ([5555350](https://git.schaub-dev.xyz/cppuniverse/libcute/commit/55553500bdc85f506de28725cf9816dd939b3f39)) - Fabrice
+- add list and dlist containers
+- add insert-before/after operations and iterators for list containers
 
 ### Fmt
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ collection-features:
 - [x] bitmap (heaped)
       Bitsets keep their storage inline and provide fast, stack-friendly access.
       Bitmaps allocate their storage on the heap and are used for larger dynamic sets.
-- [ ] linked and doubly linked
+ - [x] linked and doubly linked
 - [x] ring buffer
 
 method-features:

--- a/include/collection/dlist.h
+++ b/include/collection/dlist.h
@@ -1,0 +1,60 @@
+#pragma once
+
+/** @file dlist.h Doubly linked list container. */
+
+#include "macro.h"
+#include "memory/allocator.h"
+#include "object/optional.h"
+#include "object/result.h"
+#include "utility.h"
+#include <stddef.h>
+#include <string.h>
+
+typedef struct cu_DList_Node {
+  struct cu_DList_Node *prev;
+  struct cu_DList_Node *next;
+  unsigned char data[];
+} cu_DList_Node;
+
+typedef struct {
+  cu_DList_Node *head;
+  cu_DList_Node *tail;
+  size_t length;
+  cu_Layout layout;
+  cu_Allocator allocator;
+} cu_DList;
+
+typedef enum {
+  CU_DLIST_ERROR_NONE = 0,
+  CU_DLIST_ERROR_OOM,
+  CU_DLIST_ERROR_INVALID_LAYOUT,
+  CU_DLIST_ERROR_INVALID,
+  CU_DLIST_ERROR_EMPTY,
+} cu_DList_Error;
+
+CU_RESULT_DECL(cu_DList, cu_DList, cu_DList_Error)
+CU_OPTIONAL_DECL(cu_DList_Error, cu_DList_Error)
+
+cu_DList_Result cu_DList_create(cu_Allocator allocator, cu_Layout layout);
+void cu_DList_destroy(cu_DList *list);
+
+static inline size_t cu_DList_size(const cu_DList *list) {
+  CU_IF_NULL(list) { return 0; }
+  return list->length;
+}
+
+static inline bool cu_DList_is_empty(const cu_DList *list) {
+  CU_IF_NULL(list) { return true; }
+  return list->length == 0;
+}
+
+cu_DList_Error_Optional cu_DList_push_front(cu_DList *list, void *elem);
+cu_DList_Error_Optional cu_DList_push_back(cu_DList *list, void *elem);
+cu_DList_Error_Optional cu_DList_pop_front(cu_DList *list, void *out_elem);
+cu_DList_Error_Optional cu_DList_pop_back(cu_DList *list, void *out_elem);
+cu_DList_Error_Optional cu_DList_insert_after(
+    cu_DList *list, cu_DList_Node *pos, void *elem);
+cu_DList_Error_Optional cu_DList_insert_before(
+    cu_DList *list, cu_DList_Node *pos, void *elem);
+
+bool cu_DList_iter(const cu_DList *list, cu_DList_Node **node, void **out_elem);

--- a/include/collection/list.h
+++ b/include/collection/list.h
@@ -1,0 +1,56 @@
+#pragma once
+
+/** @file list.h Singly linked list container. */
+
+#include "macro.h"
+#include "memory/allocator.h"
+#include "object/optional.h"
+#include "object/result.h"
+#include "utility.h"
+#include <stddef.h>
+#include <string.h>
+
+typedef struct cu_List_Node {
+  struct cu_List_Node *next;
+  unsigned char data[];
+} cu_List_Node;
+
+typedef struct {
+  cu_List_Node *head;
+  size_t length;
+  cu_Layout layout;
+  cu_Allocator allocator;
+} cu_List;
+
+typedef enum {
+  CU_LIST_ERROR_NONE = 0,
+  CU_LIST_ERROR_OOM,
+  CU_LIST_ERROR_INVALID_LAYOUT,
+  CU_LIST_ERROR_INVALID,
+  CU_LIST_ERROR_EMPTY,
+} cu_List_Error;
+
+CU_RESULT_DECL(cu_List, cu_List, cu_List_Error)
+CU_OPTIONAL_DECL(cu_List_Error, cu_List_Error)
+
+cu_List_Result cu_List_create(cu_Allocator allocator, cu_Layout layout);
+void cu_List_destroy(cu_List *list);
+
+static inline size_t cu_List_size(const cu_List *list) {
+  CU_IF_NULL(list) { return 0; }
+  return list->length;
+}
+
+static inline bool cu_List_is_empty(const cu_List *list) {
+  CU_IF_NULL(list) { return true; }
+  return list->length == 0;
+}
+
+cu_List_Error_Optional cu_List_push_front(cu_List *list, void *elem);
+cu_List_Error_Optional cu_List_pop_front(cu_List *list, void *out_elem);
+cu_List_Error_Optional cu_List_insert_after(
+    cu_List *list, cu_List_Node *node, void *elem);
+cu_List_Error_Optional cu_List_insert_before(
+    cu_List *list, cu_List_Node *node, void *elem);
+
+bool cu_List_iter(const cu_List *list, cu_List_Node **node, void **out_elem);

--- a/include/cute.h
+++ b/include/cute.h
@@ -7,14 +7,16 @@ extern "C" {
 /** @file cute.h Umbrella header including all of libcute. */
 
 #include "memory/allocator.h"
-#include "memory/gpallocator.h"
 #include "memory/arenaallocator.h"
-#include "memory/slab.h"
+#include "memory/gpallocator.h"
 #include "memory/page.h"
+#include "memory/slab.h"
 
 #include "collection/bitmap.h"
 #include "collection/bitset.h"
+#include "collection/dlist.h"
 #include "collection/hashmap.h"
+#include "collection/list.h"
 #include "collection/ring_buffer.h"
 #include "collection/vector.h"
 
@@ -23,8 +25,8 @@ extern "C" {
 #include "object/optional.h"
 #include "object/result.h"
 #include "object/slice.h"
-#include "string/string.h"
 #include "string/fmt.h"
+#include "string/string.h"
 
 #include "utility.h"
 #ifdef __cplusplus

--- a/lib/collection/dlist.c
+++ b/lib/collection/dlist.c
@@ -1,0 +1,224 @@
+#include "collection/dlist.h"
+#include <stdalign.h>
+#include <string.h>
+
+CU_RESULT_IMPL(cu_DList, cu_DList, cu_DList_Error)
+CU_OPTIONAL_IMPL(cu_DList_Error, cu_DList_Error)
+
+cu_DList_Result cu_DList_create(cu_Allocator allocator, cu_Layout layout) {
+  CU_LAYOUT_CHECK(layout) {
+    return cu_DList_result_error(CU_DLIST_ERROR_INVALID_LAYOUT);
+  }
+  cu_DList list;
+  list.head = NULL;
+  list.tail = NULL;
+  list.length = 0;
+  list.layout = layout;
+  list.allocator = allocator;
+  return cu_DList_result_ok(list);
+}
+
+void cu_DList_destroy(cu_DList *list) {
+  if (!list) {
+    return;
+  }
+  cu_DList_Node *n = list->head;
+  while (n) {
+    cu_DList_Node *next = n->next;
+    cu_Allocator_Free(list->allocator,
+        cu_Slice_create(n, sizeof(cu_DList_Node) + list->layout.elem_size));
+    n = next;
+  }
+  list->head = NULL;
+  list->tail = NULL;
+  list->length = 0;
+}
+
+static cu_DList_Error_Optional cu_DList_alloc_node(
+    cu_DList *list, void *elem, cu_DList_Node **out_node) {
+  size_t size = sizeof(cu_DList_Node) + list->layout.elem_size;
+  cu_Slice_Optional mem =
+      cu_Allocator_Alloc(list->allocator, size, alignof(cu_DList_Node));
+  if (cu_Slice_Optional_is_none(&mem)) {
+    return cu_DList_Error_Optional_some(CU_DLIST_ERROR_OOM);
+  }
+  cu_DList_Node *node = (cu_DList_Node *)mem.value.ptr;
+  memcpy(node->data, elem, list->layout.elem_size);
+  node->prev = NULL;
+  node->next = NULL;
+  *out_node = node;
+  return cu_DList_Error_Optional_none();
+}
+
+cu_DList_Error_Optional cu_DList_push_front(cu_DList *list, void *elem) {
+  CU_IF_NULL(list) {
+    return cu_DList_Error_Optional_some(CU_DLIST_ERROR_INVALID);
+  }
+  CU_LAYOUT_CHECK(list->layout) {
+    return cu_DList_Error_Optional_some(CU_DLIST_ERROR_INVALID_LAYOUT);
+  }
+  cu_DList_Node *node = NULL;
+  cu_DList_Error_Optional err = cu_DList_alloc_node(list, elem, &node);
+  if (cu_DList_Error_Optional_is_some(&err)) {
+    return err;
+  }
+  node->next = list->head;
+  if (list->head) {
+    list->head->prev = node;
+  } else {
+    list->tail = node;
+  }
+  list->head = node;
+  list->length++;
+  return cu_DList_Error_Optional_none();
+}
+
+cu_DList_Error_Optional cu_DList_push_back(cu_DList *list, void *elem) {
+  CU_IF_NULL(list) {
+    return cu_DList_Error_Optional_some(CU_DLIST_ERROR_INVALID);
+  }
+  CU_LAYOUT_CHECK(list->layout) {
+    return cu_DList_Error_Optional_some(CU_DLIST_ERROR_INVALID_LAYOUT);
+  }
+  cu_DList_Node *node = NULL;
+  cu_DList_Error_Optional err = cu_DList_alloc_node(list, elem, &node);
+  if (cu_DList_Error_Optional_is_some(&err)) {
+    return err;
+  }
+  node->prev = list->tail;
+  if (list->tail) {
+    list->tail->next = node;
+  } else {
+    list->head = node;
+  }
+  list->tail = node;
+  list->length++;
+  return cu_DList_Error_Optional_none();
+}
+
+cu_DList_Error_Optional cu_DList_pop_front(cu_DList *list, void *out_elem) {
+  CU_IF_NULL(list) {
+    return cu_DList_Error_Optional_some(CU_DLIST_ERROR_INVALID);
+  }
+  CU_LAYOUT_CHECK(list->layout) {
+    return cu_DList_Error_Optional_some(CU_DLIST_ERROR_INVALID_LAYOUT);
+  }
+  if (list->length == 0) {
+    return cu_DList_Error_Optional_some(CU_DLIST_ERROR_EMPTY);
+  }
+  cu_DList_Node *node = list->head;
+  memcpy(out_elem, node->data, list->layout.elem_size);
+  list->head = node->next;
+  if (list->head) {
+    list->head->prev = NULL;
+  } else {
+    list->tail = NULL;
+  }
+  list->length--;
+  cu_Allocator_Free(list->allocator,
+      cu_Slice_create(node, sizeof(cu_DList_Node) + list->layout.elem_size));
+  return cu_DList_Error_Optional_none();
+}
+
+cu_DList_Error_Optional cu_DList_pop_back(cu_DList *list, void *out_elem) {
+  CU_IF_NULL(list) {
+    return cu_DList_Error_Optional_some(CU_DLIST_ERROR_INVALID);
+  }
+  CU_LAYOUT_CHECK(list->layout) {
+    return cu_DList_Error_Optional_some(CU_DLIST_ERROR_INVALID_LAYOUT);
+  }
+  if (list->length == 0) {
+    return cu_DList_Error_Optional_some(CU_DLIST_ERROR_EMPTY);
+  }
+  cu_DList_Node *node = list->tail;
+  memcpy(out_elem, node->data, list->layout.elem_size);
+  list->tail = node->prev;
+  if (list->tail) {
+    list->tail->next = NULL;
+  } else {
+    list->head = NULL;
+  }
+  list->length--;
+  cu_Allocator_Free(list->allocator,
+      cu_Slice_create(node, sizeof(cu_DList_Node) + list->layout.elem_size));
+  return cu_DList_Error_Optional_none();
+}
+
+cu_DList_Error_Optional cu_DList_insert_after(
+    cu_DList *list, cu_DList_Node *pos, void *elem) {
+  CU_IF_NULL(list) { return cu_DList_Error_Optional_some(CU_DLIST_ERROR_INVALID); }
+  CU_LAYOUT_CHECK(list->layout) {
+    return cu_DList_Error_Optional_some(CU_DLIST_ERROR_INVALID_LAYOUT);
+  }
+  cu_DList_Node *node = NULL;
+  cu_DList_Error_Optional err = cu_DList_alloc_node(list, elem, &node);
+  if (cu_DList_Error_Optional_is_some(&err)) {
+    return err;
+  }
+
+  if (!pos) {
+    node->next = list->head;
+    if (list->head) {
+      list->head->prev = node;
+    } else {
+      list->tail = node;
+    }
+    list->head = node;
+  } else {
+    node->next = pos->next;
+    node->prev = pos;
+    if (pos->next) {
+      pos->next->prev = node;
+    } else {
+      list->tail = node;
+    }
+    pos->next = node;
+  }
+
+  list->length++;
+  return cu_DList_Error_Optional_none();
+}
+
+cu_DList_Error_Optional cu_DList_insert_before(
+    cu_DList *list, cu_DList_Node *pos, void *elem) {
+  if (!pos) {
+    return cu_DList_insert_after(list, NULL, elem);
+  }
+  CU_IF_NULL(list) { return cu_DList_Error_Optional_some(CU_DLIST_ERROR_INVALID); }
+  CU_LAYOUT_CHECK(list->layout) {
+    return cu_DList_Error_Optional_some(CU_DLIST_ERROR_INVALID_LAYOUT);
+  }
+
+  cu_DList_Node *node = NULL;
+  cu_DList_Error_Optional err = cu_DList_alloc_node(list, elem, &node);
+  if (cu_DList_Error_Optional_is_some(&err)) {
+    return err;
+  }
+
+  node->prev = pos->prev;
+  node->next = pos;
+  if (pos->prev) {
+    pos->prev->next = node;
+  } else {
+    list->head = node;
+  }
+  pos->prev = node;
+  list->length++;
+  return cu_DList_Error_Optional_none();
+}
+
+bool cu_DList_iter(
+    const cu_DList *list, cu_DList_Node **node, void **out_elem) {
+  CU_IF_NULL(list) { return false; }
+  CU_IF_NULL(node) { return false; }
+  CU_IF_NULL(out_elem) { return false; }
+  CU_LAYOUT_CHECK(list->layout) { return false; }
+
+  cu_DList_Node *cur = *node ? (*node)->next : list->head;
+  if (!cur) {
+    return false;
+  }
+  *node = cur;
+  *out_elem = cur->data;
+  return true;
+}

--- a/lib/collection/list.c
+++ b/lib/collection/list.c
@@ -1,0 +1,142 @@
+#include "collection/list.h"
+#include <stdalign.h>
+#include <string.h>
+
+CU_RESULT_IMPL(cu_List, cu_List, cu_List_Error)
+CU_OPTIONAL_IMPL(cu_List_Error, cu_List_Error)
+
+cu_List_Result cu_List_create(cu_Allocator allocator, cu_Layout layout) {
+  CU_LAYOUT_CHECK(layout) {
+    return cu_List_result_error(CU_LIST_ERROR_INVALID_LAYOUT);
+  }
+
+  cu_List list;
+  list.head = NULL;
+  list.length = 0;
+  list.layout = layout;
+  list.allocator = allocator;
+  return cu_List_result_ok(list);
+}
+
+void cu_List_destroy(cu_List *list) {
+  if (!list) {
+    return;
+  }
+  cu_List_Node *n = list->head;
+  while (n) {
+    cu_List_Node *next = n->next;
+    cu_Allocator_Free(list->allocator,
+        cu_Slice_create(n, sizeof(cu_List_Node) + list->layout.elem_size));
+    n = next;
+  }
+  list->head = NULL;
+  list->length = 0;
+}
+
+cu_List_Error_Optional cu_List_push_front(cu_List *list, void *elem) {
+  CU_IF_NULL(list) {
+    return cu_List_Error_Optional_some(CU_LIST_ERROR_INVALID);
+  }
+  CU_LAYOUT_CHECK(list->layout) {
+    return cu_List_Error_Optional_some(CU_LIST_ERROR_INVALID_LAYOUT);
+  }
+  size_t size = sizeof(cu_List_Node) + list->layout.elem_size;
+  cu_Slice_Optional mem =
+      cu_Allocator_Alloc(list->allocator, size, alignof(cu_List_Node));
+  if (cu_Slice_Optional_is_none(&mem)) {
+    return cu_List_Error_Optional_some(CU_LIST_ERROR_OOM);
+  }
+  cu_List_Node *node = (cu_List_Node *)mem.value.ptr;
+  node->next = list->head;
+  memcpy(node->data, elem, list->layout.elem_size);
+  list->head = node;
+  list->length++;
+  return cu_List_Error_Optional_none();
+}
+
+cu_List_Error_Optional cu_List_pop_front(cu_List *list, void *out_elem) {
+  CU_IF_NULL(list) {
+    return cu_List_Error_Optional_some(CU_LIST_ERROR_INVALID);
+  }
+  CU_LAYOUT_CHECK(list->layout) {
+    return cu_List_Error_Optional_some(CU_LIST_ERROR_INVALID_LAYOUT);
+  }
+  if (list->length == 0) {
+    return cu_List_Error_Optional_some(CU_LIST_ERROR_EMPTY);
+  }
+  cu_List_Node *node = list->head;
+  memcpy(out_elem, node->data, list->layout.elem_size);
+  list->head = node->next;
+  list->length--;
+  cu_Allocator_Free(list->allocator,
+      cu_Slice_create(node, sizeof(cu_List_Node) + list->layout.elem_size));
+  return cu_List_Error_Optional_none();
+}
+
+cu_List_Error_Optional cu_List_insert_after(
+    cu_List *list, cu_List_Node *pos, void *elem) {
+  CU_IF_NULL(list) { return cu_List_Error_Optional_some(CU_LIST_ERROR_INVALID); }
+  CU_LAYOUT_CHECK(list->layout) {
+    return cu_List_Error_Optional_some(CU_LIST_ERROR_INVALID_LAYOUT);
+  }
+
+  size_t size = sizeof(cu_List_Node) + list->layout.elem_size;
+  cu_Slice_Optional mem =
+      cu_Allocator_Alloc(list->allocator, size, alignof(cu_List_Node));
+  if (cu_Slice_Optional_is_none(&mem)) {
+    return cu_List_Error_Optional_some(CU_LIST_ERROR_OOM);
+  }
+
+  cu_List_Node *node = (cu_List_Node *)mem.value.ptr;
+  memcpy(node->data, elem, list->layout.elem_size);
+
+  if (!pos) {
+    node->next = list->head;
+    list->head = node;
+  } else {
+    node->next = pos->next;
+    pos->next = node;
+  }
+
+  list->length++;
+  return cu_List_Error_Optional_none();
+}
+
+cu_List_Error_Optional cu_List_insert_before(
+    cu_List *list, cu_List_Node *pos, void *elem) {
+  if (!pos) {
+    return cu_List_insert_after(list, NULL, elem);
+  }
+  CU_IF_NULL(list) { return cu_List_Error_Optional_some(CU_LIST_ERROR_INVALID); }
+  CU_LAYOUT_CHECK(list->layout) {
+    return cu_List_Error_Optional_some(CU_LIST_ERROR_INVALID_LAYOUT);
+  }
+
+  if (pos == list->head) {
+    return cu_List_insert_after(list, NULL, elem);
+  }
+
+  cu_List_Node *prev = list->head;
+  while (prev && prev->next != pos) {
+    prev = prev->next;
+  }
+  if (!prev) {
+    return cu_List_Error_Optional_some(CU_LIST_ERROR_INVALID);
+  }
+  return cu_List_insert_after(list, prev, elem);
+}
+
+bool cu_List_iter(const cu_List *list, cu_List_Node **node, void **out_elem) {
+  CU_IF_NULL(list) { return false; }
+  CU_IF_NULL(node) { return false; }
+  CU_IF_NULL(out_elem) { return false; }
+  CU_LAYOUT_CHECK(list->layout) { return false; }
+
+  cu_List_Node *cur = *node ? (*node)->next : list->head;
+  if (!cur) {
+    return false;
+  }
+  *node = cur;
+  *out_elem = cur->data;
+  return true;
+}

--- a/meson.build
+++ b/meson.build
@@ -20,6 +20,8 @@ sources = [
   'lib/string/string.c',
   'lib/string/fmt.c',
   'lib/collection/ring_buffer.c',
+  'lib/collection/list.c',
+  'lib/collection/dlist.c',
   'lib/collection/vector.c',
   'lib/collection/hashmap.c',
 ]

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -13,6 +13,8 @@ test_files = [
   'test_page_allocator.cpp',
   'test_slab_allocator.cpp',
   'test_ring_buffer.cpp',
+  'test_list.cpp',
+  'test_dlist.cpp',
   'test_vector.cpp',
   'test_arena_allocator.cpp',
   'test_fmt.cpp',

--- a/tests/test_dlist.cpp
+++ b/tests/test_dlist.cpp
@@ -1,0 +1,78 @@
+extern "C" {
+#include "collection/dlist.h"
+#include "memory/allocator.h"
+#include "memory/gpallocator.h"
+#include "memory/page.h"
+}
+#include <gtest/gtest.h>
+
+static cu_Allocator create_allocator(
+    cu_GPAllocator *gpa, cu_PageAllocator *page) {
+  cu_Allocator page_alloc = cu_Allocator_PageAllocator(page);
+  cu_GPAllocator_Config cfg = {};
+  cfg.bucketSize = CU_GPA_BUCKET_SIZE;
+  cfg.backingAllocator = cu_Allocator_Optional_some(page_alloc);
+  return cu_Allocator_GPAllocator(gpa, cfg);
+}
+
+TEST(DList, PushPop) {
+  cu_PageAllocator page;
+  cu_GPAllocator gpa;
+  cu_Allocator alloc = create_allocator(&gpa, &page);
+
+  cu_DList_Result res = cu_DList_create(alloc, CU_LAYOUT(int));
+  ASSERT_TRUE(cu_DList_result_is_ok(&res));
+  cu_DList list = cu_DList_result_unwrap(&res);
+
+  for (int i = 0; i < 3; ++i) {
+    cu_DList_Error_Optional err = cu_DList_push_back(&list, &i);
+    ASSERT_TRUE(cu_DList_Error_Optional_is_none(&err));
+  }
+  EXPECT_EQ(cu_DList_size(&list), 3u);
+
+  int out = -1;
+  cu_DList_Error_Optional err = cu_DList_pop_front(&list, &out);
+  ASSERT_TRUE(cu_DList_Error_Optional_is_none(&err));
+  EXPECT_EQ(out, 0);
+
+  err = cu_DList_pop_back(&list, &out);
+  ASSERT_TRUE(cu_DList_Error_Optional_is_none(&err));
+  EXPECT_EQ(out, 2);
+
+  cu_DList_destroy(&list);
+  cu_GPAllocator_destroy(&gpa);
+}
+
+TEST(DList, InsertIter) {
+  cu_PageAllocator page;
+  cu_GPAllocator gpa;
+  cu_Allocator alloc = create_allocator(&gpa, &page);
+
+  cu_DList_Result res = cu_DList_create(alloc, CU_LAYOUT(int));
+  ASSERT_TRUE(cu_DList_result_is_ok(&res));
+  cu_DList list = cu_DList_result_unwrap(&res);
+
+  for (int i = 0; i < 2; ++i) {
+    cu_DList_push_back(&list, &i); // 0,1
+  }
+
+  cu_DList_Node *node = list.head;
+  int v = 42;
+  cu_DList_insert_after(&list, node, &v); // 0,42,1
+
+  v = 99;
+  cu_DList_insert_before(&list, list.head, &v); // 99,0,42,1
+
+  int expected[] = {99, 0, 42, 1};
+  size_t idx = 0;
+  cu_DList_Node *it = NULL;
+  void *elem = NULL;
+  while (cu_DList_iter(&list, &it, &elem)) {
+    ASSERT_LT(idx, CU_ARRAY_LEN(expected));
+    EXPECT_EQ(*(int *)elem, expected[idx++]);
+  }
+  EXPECT_EQ(idx, CU_ARRAY_LEN(expected));
+
+  cu_DList_destroy(&list);
+  cu_GPAllocator_destroy(&gpa);
+}

--- a/tests/test_list.cpp
+++ b/tests/test_list.cpp
@@ -1,0 +1,81 @@
+extern "C" {
+#include "collection/list.h"
+#include "memory/allocator.h"
+#include "memory/gpallocator.h"
+#include "memory/page.h"
+}
+#include <gtest/gtest.h>
+
+static cu_Allocator create_allocator(
+    cu_GPAllocator *gpa, cu_PageAllocator *page) {
+  cu_Allocator page_alloc = cu_Allocator_PageAllocator(page);
+  cu_GPAllocator_Config cfg = {};
+  cfg.bucketSize = CU_GPA_BUCKET_SIZE;
+  cfg.backingAllocator = cu_Allocator_Optional_some(page_alloc);
+  return cu_Allocator_GPAllocator(gpa, cfg);
+}
+
+TEST(List, PushPop) {
+  cu_PageAllocator page;
+  cu_GPAllocator gpa;
+  cu_Allocator alloc = create_allocator(&gpa, &page);
+
+  cu_List_Result res = cu_List_create(alloc, CU_LAYOUT(int));
+  ASSERT_TRUE(cu_List_result_is_ok(&res));
+  cu_List list = cu_List_result_unwrap(&res);
+
+  for (int i = 0; i < 4; ++i) {
+    cu_List_Error_Optional err = cu_List_push_front(&list, &i);
+    ASSERT_TRUE(cu_List_Error_Optional_is_none(&err));
+  }
+  EXPECT_EQ(cu_List_size(&list), 4u);
+
+  for (int i = 3; i >= 0; --i) {
+    int out = -1;
+    cu_List_Error_Optional err = cu_List_pop_front(&list, &out);
+    ASSERT_TRUE(cu_List_Error_Optional_is_none(&err));
+    EXPECT_EQ(out, i);
+  }
+  EXPECT_TRUE(cu_List_is_empty(&list));
+
+  cu_List_destroy(&list);
+  cu_GPAllocator_destroy(&gpa);
+}
+
+TEST(List, InsertIter) {
+  cu_PageAllocator page;
+  cu_GPAllocator gpa;
+  cu_Allocator alloc = create_allocator(&gpa, &page);
+
+  cu_List_Result r = cu_List_create(alloc, CU_LAYOUT(int));
+  ASSERT_TRUE(cu_List_result_is_ok(&r));
+  cu_List list = cu_List_result_unwrap(&r);
+
+  for (int i = 0; i < 3; ++i) {
+    cu_List_push_front(&list, &i); // 2,1,0
+  }
+
+  cu_List_Node *node = list.head;
+  int val = 42;
+  cu_List_Error_Optional err = cu_List_insert_after(&list, node, &val);
+  ASSERT_TRUE(cu_List_Error_Optional_is_none(&err)); // list:2,42,1,0
+
+  node = list.head; // head 2
+  while (node->next->next) node = node->next; // node at 1
+  val = 99;
+  err = cu_List_insert_before(&list, node->next, &val); // before 0
+  ASSERT_TRUE(cu_List_Error_Optional_is_none(&err));
+
+  int expected[] = {2, 42, 1, 99, 0};
+  size_t idx = 0;
+  cu_List_Node *it = NULL;
+  void *elem = NULL;
+  while (cu_List_iter(&list, &it, &elem)) {
+    ASSERT_LT(idx, CU_ARRAY_LEN(expected));
+    EXPECT_EQ(*(int *)elem, expected[idx++]);
+  }
+  EXPECT_EQ(idx, CU_ARRAY_LEN(expected));
+
+  cu_List_destroy(&list);
+  cu_GPAllocator_destroy(&gpa);
+}


### PR DESCRIPTION
## Summary
- extend singly and doubly linked list APIs with insert-before/after operations
- expose new API functions in headers
- add tests demonstrating inserts and iteration
- document the additions in the changelog

## Testing
- `python3 meson-1.8.2/meson.py setup build -Dtests=enabled`
- `ninja -C build`
- `meson test -C build --print-errorlogs`


------
https://chatgpt.com/codex/tasks/task_e_68793e142ce0833397447936d2ca68d7