### PR TITLE
Refine worker pool header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ All notable changes to this project will be documented in this file. See [conven
 - adds bitmap type - ([d0b722c](https://git.schaub-dev.xyz/cppuniverse/libcute/commit/d0b722cc539b83a4dd722960faba92a604548b6f)) - Fabrice
 - adds faulty vector type - ([05563aa](https://git.schaub-dev.xyz/cppuniverse/libcute/commit/05563aa26c7bf347d5cbd4f4d204d58b81be650f)) - Fabrice
 - copy whole arrays - ([9e54a5f](https://git.schaub-dev.xyz/cppuniverse/libcute/commit/9e54a5f1b2b23f8c57c0d661cbcd157b413d2c35)) - Fabrice
+- add worker pool abstraction
+- improve worker pool configuration and add tests
 
 ### Refactoring
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ method-features:
 
 - [x] hashing methods FNV-1A, Murmur3, SipHash (tied to hashmap, stil separate)
 
+worker-features:
+
+- [x] worker pool with stealing scheduler
+
 ## Todo's
 
 - [x] Rename optional generated methods to include `Optional` in the name

--- a/include/cute.h
+++ b/include/cute.h
@@ -1,5 +1,4 @@
 #pragma once
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -19,6 +18,8 @@ extern "C" {
 #include "collection/list.h"
 #include "collection/ring_buffer.h"
 #include "collection/vector.h"
+
+#include "worker/pool.h"
 
 #include "hash/hash.h"
 #include "macro.h"

--- a/include/worker/pool.h
+++ b/include/worker/pool.h
@@ -1,0 +1,63 @@
+#pragma once
+
+/** @file pool.h Simple worker pool with work stealing. */
+
+#include "collection/ring_buffer.h"
+#include "memory/allocator.h"
+#include "object/optional.h"
+#include <pthread.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+typedef void (*cu_TaskFn)(void *data);
+
+typedef struct cu_WorkerPool cu_WorkerPool;
+
+#define CU_WORKERPOOL_DEFAULT_QUEUE_CAPACITY 64
+
+typedef struct {
+  size_t workers;
+  size_t queueCapacity;
+  cu_Allocator_Optional allocator;
+} cu_WorkerPool_Config;
+
+/** Task executed by a worker. */
+typedef struct {
+  cu_TaskFn fn;
+  void *data;
+} cu_Task;
+
+/** Worker executing tasks from its queue. */
+typedef struct cu_Worker {
+  pthread_t thread;      /**< worker thread */
+  cu_RingBuffer queue;   /**< pending tasks */
+  pthread_mutex_t mutex; /**< queue lock */
+  pthread_cond_t cond;   /**< wake signal */
+  bool stop;             /**< request termination */
+  cu_WorkerPool *pool;   /**< owning pool */
+  size_t index;          /**< worker index */
+} cu_Worker;
+
+/** Pool managing multiple workers and scheduling tasks. */
+typedef struct cu_WorkerPool {
+  cu_Worker *workers;
+  size_t count;
+  cu_Allocator allocator;
+  size_t next;
+  size_t queueCapacity;
+} cu_WorkerPool;
+
+/** Error codes returned by worker pool operations. */
+typedef enum {
+  CU_WORKERPOOL_ERROR_NONE = 0,
+  CU_WORKERPOOL_ERROR_OOM,
+  CU_WORKERPOOL_ERROR_INVALID,
+} cu_WorkerPool_Error;
+
+CU_OPTIONAL_DECL(cu_WorkerPool_Error, cu_WorkerPool_Error)
+
+cu_WorkerPool_Error cu_WorkerPool_create(
+    cu_WorkerPool *pool, cu_WorkerPool_Config config);
+void cu_WorkerPool_destroy(cu_WorkerPool *pool);
+cu_WorkerPool_Error_Optional cu_WorkerPool_schedule(
+    cu_WorkerPool *pool, cu_Task task);

--- a/lib/worker/pool.c
+++ b/lib/worker/pool.c
@@ -1,0 +1,182 @@
+#include "worker/pool.h"
+#include "macro.h"
+#include "utility.h"
+#include <stdalign.h>
+#include <stdatomic.h>
+#include <stdlib.h>
+#include <string.h>
+
+CU_OPTIONAL_IMPL(cu_WorkerPool_Error, cu_WorkerPool_Error)
+
+static bool steal_task(cu_Worker *worker, cu_Task *out) {
+  cu_WorkerPool *pool = worker->pool;
+  for (size_t i = 0; i < pool->count; ++i) {
+    cu_Worker *victim = &pool->workers[(worker->index + i + 1) % pool->count];
+    if (victim == worker) {
+      continue;
+    }
+    if (pthread_mutex_trylock(&victim->mutex) == 0) {
+      if (!cu_RingBuffer_is_empty(&victim->queue)) {
+        cu_RingBuffer_pop(&victim->queue, out);
+        pthread_mutex_unlock(&victim->mutex);
+        return true;
+      }
+      pthread_mutex_unlock(&victim->mutex);
+    }
+  }
+  return false;
+}
+
+static void *worker_main(void *arg) {
+  cu_Worker *worker = arg;
+  for (;;) {
+    cu_Task task;
+    bool have_task = false;
+
+    pthread_mutex_lock(&worker->mutex);
+    if (!cu_RingBuffer_is_empty(&worker->queue)) {
+      cu_RingBuffer_pop(&worker->queue, &task);
+      have_task = true;
+    } else if (worker->stop) {
+      pthread_mutex_unlock(&worker->mutex);
+      break;
+    }
+    pthread_mutex_unlock(&worker->mutex);
+
+    if (!have_task) {
+      if (steal_task(worker, &task)) {
+        have_task = true;
+      }
+    }
+
+    if (have_task) {
+      task.fn(task.data);
+      continue;
+    }
+
+    pthread_mutex_lock(&worker->mutex);
+    if (!worker->stop && cu_RingBuffer_is_empty(&worker->queue)) {
+      pthread_cond_wait(&worker->cond, &worker->mutex);
+    }
+    bool quit = worker->stop && cu_RingBuffer_is_empty(&worker->queue);
+    pthread_mutex_unlock(&worker->mutex);
+    if (quit) {
+      break;
+    }
+  }
+  return NULL;
+}
+
+static cu_WorkerPool_Error worker_init(cu_Worker *worker,
+    cu_Allocator allocator, cu_WorkerPool *pool, size_t index,
+    size_t capacity) {
+  if (pthread_mutex_init(&worker->mutex, NULL) != 0) {
+    return CU_WORKERPOOL_ERROR_OOM;
+  }
+  if (pthread_cond_init(&worker->cond, NULL) != 0) {
+    pthread_mutex_destroy(&worker->mutex);
+    return CU_WORKERPOOL_ERROR_OOM;
+  }
+  cu_RingBuffer_Result qr =
+      cu_RingBuffer_create(allocator, CU_LAYOUT(cu_Task), capacity);
+  if (!cu_RingBuffer_result_is_ok(&qr)) {
+    pthread_cond_destroy(&worker->cond);
+    pthread_mutex_destroy(&worker->mutex);
+    return CU_WORKERPOOL_ERROR_OOM;
+  }
+  worker->queue = qr.value;
+  worker->stop = false;
+  worker->pool = pool;
+  worker->index = index;
+  if (pthread_create(&worker->thread, NULL, worker_main, worker) != 0) {
+    cu_RingBuffer_destroy(&worker->queue);
+    pthread_cond_destroy(&worker->cond);
+    pthread_mutex_destroy(&worker->mutex);
+    return CU_WORKERPOOL_ERROR_OOM;
+  }
+  return CU_WORKERPOOL_ERROR_NONE;
+}
+
+cu_WorkerPool_Error cu_WorkerPool_create(
+    cu_WorkerPool *pool, cu_WorkerPool_Config config) {
+  if (!pool || config.workers == 0) {
+    return CU_WORKERPOOL_ERROR_INVALID;
+  }
+  cu_Allocator allocator = cu_Allocator_Optional_is_some(&config.allocator)
+                               ? config.allocator.value
+                               : cu_Allocator_CAllocator();
+  size_t capacity = config.queueCapacity ? config.queueCapacity
+                                         : CU_WORKERPOOL_DEFAULT_QUEUE_CAPACITY;
+  size_t size = sizeof(cu_Worker) * config.workers;
+  cu_Slice_Optional mem =
+      cu_Allocator_Alloc(allocator, size, alignof(cu_Worker));
+  if (cu_Slice_Optional_is_none(&mem)) {
+    return CU_WORKERPOOL_ERROR_OOM;
+  }
+  pool->workers = mem.value.ptr;
+  pool->count = config.workers;
+  pool->allocator = allocator;
+  pool->next = 0;
+  pool->queueCapacity = capacity;
+  memset(pool->workers, 0, size);
+  for (size_t i = 0; i < config.workers; ++i) {
+    cu_WorkerPool_Error err =
+        worker_init(&pool->workers[i], allocator, pool, i, capacity);
+    if (err != CU_WORKERPOOL_ERROR_NONE) {
+      for (size_t j = 0; j < i; ++j) {
+        pthread_mutex_lock(&pool->workers[j].mutex);
+        pool->workers[j].stop = true;
+        pthread_cond_signal(&pool->workers[j].cond);
+        pthread_mutex_unlock(&pool->workers[j].mutex);
+        pthread_join(pool->workers[j].thread, NULL);
+        cu_RingBuffer_destroy(&pool->workers[j].queue);
+        pthread_cond_destroy(&pool->workers[j].cond);
+        pthread_mutex_destroy(&pool->workers[j].mutex);
+      }
+      cu_Allocator_Free(allocator, mem.value);
+      return err;
+    }
+  }
+  return CU_WORKERPOOL_ERROR_NONE;
+}
+
+void cu_WorkerPool_destroy(cu_WorkerPool *pool) {
+  if (!pool || !pool->workers) {
+    return;
+  }
+  for (size_t i = 0; i < pool->count; ++i) {
+    pthread_mutex_lock(&pool->workers[i].mutex);
+    pool->workers[i].stop = true;
+    pthread_cond_signal(&pool->workers[i].cond);
+    pthread_mutex_unlock(&pool->workers[i].mutex);
+    pthread_join(pool->workers[i].thread, NULL);
+    cu_RingBuffer_destroy(&pool->workers[i].queue);
+    pthread_cond_destroy(&pool->workers[i].cond);
+    pthread_mutex_destroy(&pool->workers[i].mutex);
+  }
+  cu_Allocator_Free(pool->allocator,
+      cu_Slice_create(pool->workers, sizeof(cu_Worker) * pool->count));
+  pool->workers = NULL;
+  pool->count = 0;
+}
+
+cu_WorkerPool_Error_Optional cu_WorkerPool_schedule(
+    cu_WorkerPool *pool, cu_Task task) {
+  if (!pool || pool->count == 0) {
+    return cu_WorkerPool_Error_Optional_some(CU_WORKERPOOL_ERROR_INVALID);
+  }
+  size_t start =
+      atomic_fetch_add((atomic_size_t *)&pool->next, 1) % pool->count;
+  for (size_t i = 0; i < pool->count; ++i) {
+    cu_Worker *w = &pool->workers[(start + i) % pool->count];
+    pthread_mutex_lock(&w->mutex);
+    if (!cu_RingBuffer_is_full(&w->queue)) {
+      cu_RingBuffer_push(&w->queue, &task);
+      pthread_cond_signal(&w->cond);
+      pthread_mutex_unlock(&w->mutex);
+      return cu_WorkerPool_Error_Optional_none();
+    }
+    pthread_mutex_unlock(&w->mutex);
+  }
+  return cu_WorkerPool_Error_Optional_some(CU_WORKERPOOL_ERROR_OOM);
+}

--- a/meson.build
+++ b/meson.build
@@ -24,6 +24,7 @@ sources = [
   'lib/collection/dlist.c',
   'lib/collection/vector.c',
   'lib/collection/hashmap.c',
+  'lib/worker/pool.c',
 ]
 
 cute_lib = library(

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -18,6 +18,7 @@ test_files = [
   'test_vector.cpp',
   'test_arena_allocator.cpp',
   'test_fmt.cpp',
+  'test_worker_pool.cpp',
 ]
 
 foreach test_file : test_files

--- a/tests/test_worker_pool.cpp
+++ b/tests/test_worker_pool.cpp
@@ -1,0 +1,60 @@
+#include <atomic>
+extern "C" {
+#include "macro.h"
+#include "memory/allocator.h"
+#include "memory/gpallocator.h"
+#include "memory/page.h"
+#include "worker/pool.h"
+}
+#include <gtest/gtest.h>
+
+static cu_Allocator create_allocator(
+    cu_GPAllocator *gpa, cu_PageAllocator *page) {
+  cu_Allocator page_alloc = cu_Allocator_PageAllocator(page);
+  cu_GPAllocator_Config cfg = {};
+  cfg.bucketSize = CU_GPA_BUCKET_SIZE;
+  cfg.backingAllocator = cu_Allocator_Optional_some(page_alloc);
+  return cu_Allocator_GPAllocator(gpa, cfg);
+}
+
+static std::atomic_int counter;
+
+static void inc_task(void *data) {
+  CU_UNUSED(data);
+  counter.fetch_add(1);
+}
+
+TEST(WorkerPool, BasicRun) {
+  cu_PageAllocator page;
+  cu_GPAllocator gpa;
+  cu_Allocator alloc = create_allocator(&gpa, &page);
+
+  cu_WorkerPool_Config cfg = {};
+  cfg.workers = 2;
+  cfg.queueCapacity = 4;
+  cfg.allocator = cu_Allocator_Optional_some(alloc);
+  cu_WorkerPool pool;
+  cu_WorkerPool_Error err = cu_WorkerPool_create(&pool, cfg);
+  ASSERT_EQ(err, CU_WORKERPOOL_ERROR_NONE);
+
+  counter.store(0);
+  for (int i = 0; i < 8; ++i) {
+    cu_Task t = {inc_task, NULL};
+    cu_WorkerPool_Error_Optional err = cu_WorkerPool_schedule(&pool, t);
+    ASSERT_TRUE(cu_WorkerPool_Error_Optional_is_none(&err));
+  }
+  cu_WorkerPool_destroy(&pool);
+  EXPECT_EQ(counter.load(), 8);
+
+  cu_GPAllocator_destroy(&gpa);
+}
+
+TEST(WorkerPool, Invalid) {
+  cu_WorkerPool_Config cfg = {};
+  cfg.workers = 0;
+  cfg.queueCapacity = 1;
+  cfg.allocator = cu_Allocator_Optional_some(cu_Allocator_CAllocator());
+  cu_WorkerPool pool;
+  cu_WorkerPool_Error err = cu_WorkerPool_create(&pool, cfg);
+  EXPECT_NE(err, CU_WORKERPOOL_ERROR_NONE);
+}


### PR DESCRIPTION
## Summary
- remove C++ handling from worker pool header
- store scheduler index as plain size_t and cast to atomic in C
- adjust scheduling logic to use the casted atomic

## Testing
- `python3 meson-1.8.2/meson.py setup build -Dtests=enabled`
- `ninja -C build`
- `python3 meson-1.8.2/meson.py test -C build`


------
https://chatgpt.com/codex/tasks/task_e_6879646f652483338f52ebcaf3c904b3