### PR TITLE
Add libuv worker pool feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ meson-1.8.2/
 meson-1.8.2.tar.gz
 git-cliff-1.0.0/
 git-cliff-1.0.0-x86_64-unknown-linux-gnu.tar.gz
+subprojects/*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Changelog
+#Changelog
 
 All notable changes to this project will be documented in this file. See [conventional commits](https://www.conventionalcommits.org/) for commit guidelines.
 
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file. See [conven
 ## [unreleased]
 
 ### Bug Fixes
+
+- guard worker pool tests with libuv macro
 
 - corrected gitlab ci file name - ([3d4237e](https://git.schaub-dev.xyz/cppuniverse/libcute/commit/3d4237e0ae7f51552ee8f305850866339f6eff85)) - Fabrice
 - adds propper ci tag - ([ed4ee7b](https://git.schaub-dev.xyz/cppuniverse/libcute/commit/ed4ee7b0a9ce79ca91173fee9f0c0dc99537241c)) - Fabrice
@@ -39,6 +41,9 @@ All notable changes to this project will be documented in this file. See [conven
 
 
 ### Features
+
+- optional libuv worker pool with per-loop workers and scheduler
+- extend worker pool tests with timers and signal watchers
 
 - adds changelog - ([50e2d9a](https://git.schaub-dev.xyz/cppuniverse/libcute/commit/50e2d9abe8f10fd4afcc764475bcb4258ca85edb)) - Fabrice
 - adds bitset, starts implementing gpa, fixes macros - ([931d391](https://git.schaub-dev.xyz/cppuniverse/libcute/commit/931d391a6551b651af0f4170bf7e3d2b792b5440)) - Fabrice

--- a/include/concurrency/worker_pool.h
+++ b/include/concurrency/worker_pool.h
@@ -1,0 +1,65 @@
+#pragma once
+
+/** @file worker_pool.h Optional libuv worker pool. */
+
+#ifdef CU_USE_LIBUV
+#include "collection/ring_buffer.h"
+#include "memory/allocator.h"
+#include "object/optional.h"
+#include "object/result.h"
+#include <stdbool.h>
+#include <uv.h>
+
+/** Task callback signature providing the worker loop. */
+typedef void (*cu_WorkerTaskFn)(uv_loop_t *loop, void *data);
+
+/** Single task item. */
+typedef struct {
+  cu_WorkerTaskFn fn; /**< task function */
+  void *data;         /**< user data */
+} cu_WorkerTask;
+
+struct cu_Scheduler;
+
+/** Worker state. */
+typedef struct {
+  uv_thread_t thread;         /**< worker thread */
+  uv_loop_t *loop;            /**< event loop */
+  uv_async_t async;           /**< async notifier */
+  uv_sem_t startSem;          /**< thread start barrier */
+  cu_RingBuffer local;        /**< local buffer */
+  bool stop;                  /**< exit flag */
+  struct cu_Scheduler *sched; /**< owning scheduler */
+} cu_Worker;
+
+/** Streaming task scheduler. */
+typedef struct cu_Scheduler {
+  cu_RingBuffer queue;    /**< task queue */
+  uv_mutex_t mutex;       /**< queue guard */
+  cu_Allocator allocator; /**< allocator */
+  size_t workerCount;     /**< number of workers */
+  size_t localCapacity;   /**< per worker buffer */
+  cu_Worker *workers;     /**< worker array */
+  size_t nextWorker;      /**< round-robin counter */
+} cu_Scheduler;
+
+/** Scheduler error codes. */
+typedef enum {
+  CU_SCHEDULER_ERROR_NONE = 0,
+  CU_SCHEDULER_ERROR_INVALID,
+  CU_SCHEDULER_ERROR_OOM,
+  CU_SCHEDULER_ERROR_LIBUV,
+} cu_Scheduler_Error;
+
+CU_RESULT_DECL(cu_Scheduler, cu_Scheduler, cu_Scheduler_Error)
+CU_OPTIONAL_DECL(cu_Scheduler_Error, cu_Scheduler_Error)
+
+cu_Scheduler_Result cu_Scheduler_create(cu_Scheduler *sched,
+    cu_Allocator allocator, size_t workers, size_t queueCapacity,
+    size_t localCapacity);
+
+void cu_Scheduler_destroy(cu_Scheduler *sched);
+
+void cu_Scheduler_schedule(cu_Scheduler *sched, cu_WorkerTaskFn fn, void *data);
+
+#endif /* CU_USE_LIBUV */

--- a/include/cute.h
+++ b/include/cute.h
@@ -28,6 +28,8 @@ extern "C" {
 #include "string/fmt.h"
 #include "string/string.h"
 
+#include "concurrency/worker_pool.h"
+
 #include "utility.h"
 #ifdef __cplusplus
 }

--- a/lib/concurrency/worker_pool.c
+++ b/lib/concurrency/worker_pool.c
@@ -1,0 +1,146 @@
+#include "concurrency/worker_pool.h"
+#ifdef CU_USE_LIBUV
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+#include "macro.h"
+#include <stdalign.h>
+#include <stdlib.h>
+
+CU_RESULT_IMPL(cu_Scheduler, cu_Scheduler, cu_Scheduler_Error)
+CU_OPTIONAL_IMPL(cu_Scheduler_Error, cu_Scheduler_Error)
+
+static bool cu_worker_fill_local(cu_Worker *worker) {
+  cu_Scheduler *sched = worker->sched;
+  cu_WorkerTask item;
+  bool got = false;
+  uv_mutex_lock(&sched->mutex);
+  while (!cu_RingBuffer_is_full(&worker->local) &&
+         !cu_RingBuffer_is_empty(&sched->queue)) {
+    cu_RingBuffer_pop(&sched->queue, &item);
+    cu_RingBuffer_push(&worker->local, &item);
+    got = true;
+  }
+  uv_mutex_unlock(&sched->mutex);
+  return got;
+}
+
+static void cu_worker_async_cb(uv_async_t *handle) {
+  cu_Worker *worker = (cu_Worker *)handle->data;
+  cu_WorkerTask task;
+  while (true) {
+    if (cu_RingBuffer_is_empty(&worker->local)) {
+      if (!cu_worker_fill_local(worker)) {
+        break;
+      }
+    }
+    cu_RingBuffer_pop(&worker->local, &task);
+    if (task.fn) {
+      task.fn(worker->loop, task.data);
+    }
+  }
+  if (worker->stop) {
+    uv_stop(worker->loop);
+  }
+}
+
+static void cu_worker_thread(void *arg) {
+  cu_Worker *worker = (cu_Worker *)arg;
+  uv_loop_t loop;
+  worker->loop = &loop;
+  uv_loop_init(worker->loop);
+  uv_async_init(worker->loop, &worker->async, cu_worker_async_cb);
+  worker->async.data = worker;
+  uv_sem_post(&worker->startSem);
+  uv_run(worker->loop, UV_RUN_DEFAULT);
+  uv_close((uv_handle_t *)&worker->async, NULL);
+  uv_loop_close(worker->loop);
+}
+
+cu_Scheduler_Result cu_Scheduler_create(cu_Scheduler *sched,
+    cu_Allocator allocator, size_t workers, size_t queueCapacity,
+    size_t localCapacity) {
+  if (!sched || workers == 0) {
+    return cu_Scheduler_result_error(CU_SCHEDULER_ERROR_INVALID);
+  }
+  cu_RingBuffer_Result qres =
+      cu_RingBuffer_create(allocator, CU_LAYOUT(cu_WorkerTask), queueCapacity);
+  if (!cu_RingBuffer_result_is_ok(&qres)) {
+    return cu_Scheduler_result_error(CU_SCHEDULER_ERROR_OOM);
+  }
+  sched->queue = cu_RingBuffer_result_unwrap(&qres);
+  sched->allocator = allocator;
+  sched->workerCount = workers;
+  sched->localCapacity = localCapacity;
+  sched->nextWorker = 0;
+  uv_mutex_init(&sched->mutex);
+  cu_Slice_Optional mem = cu_Allocator_Alloc(
+      allocator, workers * sizeof(cu_Worker), alignof(cu_Worker));
+  if (cu_Slice_Optional_is_none(&mem)) {
+    cu_RingBuffer_destroy(&sched->queue);
+    return cu_Scheduler_result_error(CU_SCHEDULER_ERROR_OOM);
+  }
+  sched->workers = (cu_Worker *)mem.value.ptr;
+  for (size_t i = 0; i < workers; ++i) {
+    cu_RingBuffer_Result lres = cu_RingBuffer_create(
+        allocator, CU_LAYOUT(cu_WorkerTask), localCapacity);
+    if (!cu_RingBuffer_result_is_ok(&lres)) {
+      sched->workerCount = i;
+      cu_Scheduler_destroy(sched);
+      return cu_Scheduler_result_error(CU_SCHEDULER_ERROR_OOM);
+    }
+    uv_sem_init(&sched->workers[i].startSem, 0);
+    sched->workers[i].local = cu_RingBuffer_result_unwrap(&lres);
+    sched->workers[i].stop = false;
+    sched->workers[i].sched = sched;
+    int r = uv_thread_create(
+        &sched->workers[i].thread, cu_worker_thread, &sched->workers[i]);
+    if (r != 0) {
+      sched->workerCount = i + 1;
+      cu_Scheduler_destroy(sched);
+      return cu_Scheduler_result_error(CU_SCHEDULER_ERROR_LIBUV);
+    }
+    uv_sem_wait(&sched->workers[i].startSem);
+  }
+  return cu_Scheduler_result_ok(*sched);
+}
+
+void cu_Scheduler_destroy(cu_Scheduler *sched) {
+  if (!sched) {
+    return;
+  }
+  for (size_t i = 0; i < sched->workerCount; ++i) {
+    sched->workers[i].stop = true;
+    uv_async_send(&sched->workers[i].async);
+    uv_thread_join(&sched->workers[i].thread);
+    cu_RingBuffer_destroy(&sched->workers[i].local);
+    uv_sem_destroy(&sched->workers[i].startSem);
+  }
+  if (sched->workers) {
+    cu_Allocator_Free(
+        sched->allocator, cu_Slice_create(sched->workers,
+                              sched->workerCount * sizeof(cu_Worker)));
+    sched->workers = NULL;
+  }
+  uv_mutex_destroy(&sched->mutex);
+  cu_RingBuffer_destroy(&sched->queue);
+  sched->workerCount = 0;
+}
+
+void cu_Scheduler_schedule(
+    cu_Scheduler *sched, cu_WorkerTaskFn fn, void *data) {
+  if (!sched || !fn) {
+    return;
+  }
+  cu_WorkerTask task = {fn, data};
+  uv_mutex_lock(&sched->mutex);
+  cu_RingBuffer_Error_Optional err = cu_RingBuffer_push(&sched->queue, &task);
+  uv_mutex_unlock(&sched->mutex);
+  if (cu_RingBuffer_Error_Optional_is_some(&err)) {
+    return;
+  }
+  size_t idx = sched->nextWorker++ % sched->workerCount;
+  uv_async_send(&sched->workers[idx].async);
+}
+
+#endif /* CU_USE_LIBUV */

--- a/meson.build
+++ b/meson.build
@@ -26,15 +26,25 @@ sources = [
   'lib/collection/hashmap.c',
 ]
 
+deps = []
+if get_option('worker_pool').enabled()
+  uv_dep = dependency('libuv', fallback: ['libuv', 'libuv_dep'])
+  sources += ['lib/concurrency/worker_pool.c']
+  deps += uv_dep
+  add_project_arguments('-DCU_USE_LIBUV', '-D_GNU_SOURCE', language: ['c', 'cpp'])
+endif
+
 cute_lib = library(
   'cute',
   sources,
   include_directories: includes,
+  dependencies: deps,
 )
 
 cute_dep = declare_dependency(
   include_directories: includes,
   link_with: cute_lib,
+  dependencies: deps,
 )
 
 if get_option('tests').enabled()

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,1 +1,2 @@
 option('tests', type: 'feature', value: 'disabled', description: 'Build tests')
+option('worker_pool', type: 'feature', value: 'disabled', description: 'Enable libuv worker pool')

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -20,6 +20,10 @@ test_files = [
   'test_fmt.cpp',
 ]
 
+if get_option('worker_pool').enabled()
+  test_files += ['test_worker_pool.cpp']
+endif
+
 foreach test_file : test_files
   test_name = test_file.split('.')[0]
   exe = executable(test_name, test_file,

--- a/tests/test_worker_pool.cpp
+++ b/tests/test_worker_pool.cpp
@@ -1,0 +1,106 @@
+#ifdef CU_USE_LIBUV
+extern "C" {
+#include "concurrency/worker_pool.h"
+#include "memory/allocator.h"
+#include "memory/gpallocator.h"
+#include "memory/page.h"
+}
+#include <atomic>
+#include <gtest/gtest.h>
+#include <unistd.h>
+#include <signal.h>
+#include <uv.h>
+
+static cu_Allocator create_allocator(
+    cu_GPAllocator *gpa, cu_PageAllocator *page) {
+  cu_Allocator page_alloc = cu_Allocator_PageAllocator(page);
+  cu_GPAllocator_Config cfg = {};
+  cfg.bucketSize = CU_GPA_BUCKET_SIZE;
+  cfg.backingAllocator = cu_Allocator_Optional_some(page_alloc);
+  return cu_Allocator_GPAllocator(gpa, cfg);
+}
+
+struct TimerData {
+  uv_timer_t timer;
+  std::atomic_int *counter;
+};
+
+static void timer_close_cb(uv_handle_t *handle) {
+  auto *data = static_cast<TimerData *>(handle->data);
+  delete data;
+}
+
+static void timer_cb(uv_timer_t *t) {
+  auto *data = static_cast<TimerData *>(t->data);
+  (*data->counter)++;
+  uv_close(reinterpret_cast<uv_handle_t *>(&data->timer), timer_close_cb);
+}
+
+static void start_timer(uv_loop_t *loop, void *ptr) {
+  auto *data = static_cast<TimerData *>(ptr);
+  uv_timer_init(loop, &data->timer);
+  data->timer.data = data;
+  uv_timer_start(&data->timer, timer_cb, 5, 0);
+}
+
+struct SignalData {
+  uv_signal_t signal;
+  std::atomic_int *counter;
+};
+
+static void signal_close_cb(uv_handle_t *handle) {
+  auto *data = static_cast<SignalData *>(handle->data);
+  delete data;
+}
+
+static void signal_cb(uv_signal_t *sig, int /*signum*/) {
+  auto *data = static_cast<SignalData *>(sig->data);
+  (*data->counter)++;
+  uv_signal_stop(sig);
+  uv_close(reinterpret_cast<uv_handle_t *>(&data->signal), signal_close_cb);
+}
+
+static void start_signal(uv_loop_t *loop, void *ptr) {
+  auto *data = static_cast<SignalData *>(ptr);
+  uv_signal_init(loop, &data->signal);
+  data->signal.data = data;
+  uv_signal_start(&data->signal, signal_cb, SIGINT);
+}
+
+TEST(WorkerPool, AsyncScheduling) {
+  cu_PageAllocator page;
+  cu_GPAllocator gpa;
+  cu_Allocator alloc = create_allocator(&gpa, &page);
+
+  cu_Scheduler sched;
+  auto res = cu_Scheduler_create(&sched, alloc, 2, 16, 4);
+  ASSERT_TRUE(cu_Scheduler_result_is_ok(&res));
+  sched = cu_Scheduler_result_unwrap(&res);
+
+  std::atomic_int timers{0};
+  std::atomic_int signals{0};
+
+  auto *t1 = new TimerData{ {}, &timers };
+  auto *t2 = new TimerData{ {}, &timers };
+  auto *sig = new SignalData{ {}, &signals };
+
+  cu_Scheduler_schedule(&sched, start_timer, t1);
+  cu_Scheduler_schedule(&sched, start_timer, t2);
+  cu_Scheduler_schedule(&sched, start_signal, sig);
+
+  usleep(50000);
+  kill(getpid(), SIGINT);
+  usleep(100000);
+
+  EXPECT_EQ(timers.load(), 2);
+  EXPECT_EQ(signals.load(), 1);
+
+  cu_Scheduler_destroy(&sched);
+  cu_GPAllocator_destroy(&gpa);
+}
+#else
+#include <gtest/gtest.h>
+TEST(WorkerPool, AsyncScheduling) {
+  GTEST_SKIP() << "libuv disabled";
+}
+#endif


### PR DESCRIPTION
## Summary
- add optional worker pool with per-loop workers
- gate worker pool behind optional build flag with libuv dependency
- write basic worker pool test
- expose event loop pointer to worker tasks
- extend worker pool tests with timers and signal handling
- fix test build when libuv is disabled

## Testing
- `python3 meson-1.8.2/meson.py setup build -Dtests=enabled -Dworker_pool=enabled -Dlibuv:build_tests=false -Dlibuv:build_benchmarks=false`
- `ninja -C build`
- `python3 meson-1.8.2/meson.py test -C build`


------
https://chatgpt.com/codex/tasks/task_e_6879f497a2d48333948049b594d6d768