### PR TITLE
fix compile warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ meson-1.8.2/
 meson-1.8.2.tar.gz
 git-cliff-1.0.0/
 git-cliff-1.0.0-x86_64-unknown-linux-gnu.tar.gz
+subprojects/

--- a/examples/6502/6502.c
+++ b/examples/6502/6502.c
@@ -103,12 +103,16 @@ void cu_6502_step(cu_6502 *cpu) {
     update_zn(cpu, cpu->x);
     break;
   case 0x8D: { // STA absolute
-    uint16_t addr = mem[cpu->pc++] | ((uint16_t)mem[cpu->pc++] << 8);
+    uint8_t lo = mem[cpu->pc++];
+    uint8_t hi = mem[cpu->pc++];
+    uint16_t addr = (uint16_t)lo | ((uint16_t)hi << 8);
     mem[addr] = cpu->a;
     break;
   }
   case 0xAD: { // LDA absolute
-    uint16_t addr = mem[cpu->pc++] | ((uint16_t)mem[cpu->pc++] << 8);
+    uint8_t lo = mem[cpu->pc++];
+    uint8_t hi = mem[cpu->pc++];
+    uint16_t addr = (uint16_t)lo | ((uint16_t)hi << 8);
     cpu->a = mem[addr];
     update_zn(cpu, cpu->a);
     break;

--- a/lib/memory/arenaallocator.c
+++ b/lib/memory/arenaallocator.c
@@ -73,7 +73,6 @@ static cu_Slice_Result cu_arena_alloc(
 
 static cu_Slice_Result cu_arena_resize(
     void *self, cu_Slice mem, size_t size, size_t alignment) {
-  cu_ArenaAllocator *arena = (cu_ArenaAllocator *)self;
   if (mem.ptr == NULL) {
     return cu_arena_alloc(self, size, alignment);
   }
@@ -113,7 +112,7 @@ static cu_Slice_Result cu_arena_resize(
 }
 
 static void cu_arena_free(void *self, cu_Slice mem) {
-  cu_ArenaAllocator *arena = (cu_ArenaAllocator *)self;
+  CU_UNUSED(self);
   if (mem.ptr == NULL) {
     return;
   }


### PR DESCRIPTION
## Summary
- mark arenaallocator free function parameter unused
- stop using undefined behavior in 6502 example
- ignore subprojects directory

## Testing
- `./meson-1.8.2/meson.py compile -C build`
- `./meson-1.8.2/meson.py test -C build`


------
https://chatgpt.com/codex/tasks/task_e_687a64b3ab3c8333ae1c2df16e78fa26