### PR TITLE
Fix test failure due to errno macro clash

### DIFF
--- a/include/io/error.h
+++ b/include/io/error.h
@@ -25,8 +25,8 @@ typedef enum {
 } cu_Io_ErrorKind;
 
 typedef struct {
-  cu_Io_ErrorKind kind; // The kind of error
-  Size_Optional errno;
+  cu_Io_ErrorKind kind; /**< error kind */
+  Size_Optional errnum; /**< optional errno value */
 } cu_Io_Error;
 
 CU_OPTIONAL_DECL(cu_Io_Error, cu_Io_Error)

--- a/include/object/result.h
+++ b/include/object/result.h
@@ -28,14 +28,14 @@
 /** Implement the typed result helpers. */
 #define CU_RESULT_IMPL(NAME, T, E)                                             \
   NAME##_Result NAME##_result_ok(T value) {                                    \
-    NAME##_Result result;                                                      \
+    NAME##_Result result = {0};                                                \
     result.value = value;                                                      \
     result.isOk = true;                                                        \
     return result;                                                             \
   }                                                                            \
                                                                                \
   NAME##_Result NAME##_result_error(E error) {                                 \
-    NAME##_Result result;                                                      \
+    NAME##_Result result = {0};                                                \
     result.error = error;                                                      \
     result.isOk = false;                                                       \
     return result;                                                             \

--- a/lib/memory/allocator.c
+++ b/lib/memory/allocator.c
@@ -15,8 +15,8 @@ static cu_Slice_Result cu_CAllocator_Alloc(
   CU_UNUSED(self);
 
   if (size == 0) {
-    cu_Io_Error err = { .kind = CU_IO_ERROR_KIND_INVALID_INPUT,
-                        .errno = Size_Optional_none() };
+    cu_Io_Error err = {
+        .kind = CU_IO_ERROR_KIND_INVALID_INPUT, .errnum = Size_Optional_none()};
     return cu_Slice_result_error(err);
   }
 
@@ -24,8 +24,8 @@ static cu_Slice_Result cu_CAllocator_Alloc(
   void *ptr = malloc(alignedSize);
 
   CU_IF_NULL(ptr) {
-    cu_Io_Error err = { .kind = CU_IO_ERROR_KIND_OUT_OF_MEMORY,
-                        .errno = Size_Optional_none() };
+    cu_Io_Error err = {
+        .kind = CU_IO_ERROR_KIND_OUT_OF_MEMORY, .errnum = Size_Optional_none()};
     return cu_Slice_result_error(err);
   }
 
@@ -39,8 +39,8 @@ static cu_Slice_Result cu_CAllocator_Resize(
 
   if (size == 0) {
     cu_CAllocator_Free(NULL, mem);
-    cu_Io_Error err = { .kind = CU_IO_ERROR_KIND_INVALID_INPUT,
-                        .errno = Size_Optional_none() };
+    cu_Io_Error err = {
+        .kind = CU_IO_ERROR_KIND_INVALID_INPUT, .errnum = Size_Optional_none()};
     return cu_Slice_result_error(err);
   }
 

--- a/lib/memory/arenaallocator.c
+++ b/lib/memory/arenaallocator.c
@@ -26,7 +26,7 @@ static cu_Slice_Result cu_arena_alloc(
   cu_ArenaAllocator *arena = (cu_ArenaAllocator *)self;
   if (size == 0) {
     cu_Io_Error err = {
-        .kind = CU_IO_ERROR_KIND_INVALID_INPUT, .errno = Size_Optional_none()};
+        .kind = CU_IO_ERROR_KIND_INVALID_INPUT, .errnum = Size_Optional_none()};
     return cu_Slice_result_error(err);
   }
   if (alignment == 0) {
@@ -53,7 +53,7 @@ static cu_Slice_Result cu_arena_alloc(
     target = cu_arena_create_chunk(arena, new_size);
     if (!target) {
       cu_Io_Error err = {.kind = CU_IO_ERROR_KIND_OUT_OF_MEMORY,
-          .errno = Size_Optional_none()};
+          .errnum = Size_Optional_none()};
       return cu_Slice_result_error(err);
     }
     target->prev = arena->current;
@@ -79,7 +79,7 @@ static cu_Slice_Result cu_arena_resize(
   if (size == 0) {
     cu_arena_free(self, mem);
     cu_Io_Error err = {
-        .kind = CU_IO_ERROR_KIND_INVALID_INPUT, .errno = Size_Optional_none()};
+        .kind = CU_IO_ERROR_KIND_INVALID_INPUT, .errnum = Size_Optional_none()};
     return cu_Slice_result_error(err);
   }
   const size_t header_size = sizeof(struct cu_ArenaAllocator_Header);
@@ -89,7 +89,7 @@ static cu_Slice_Result cu_arena_resize(
   struct cu_ArenaAllocator_Chunk *chunk = hdr->chunk;
   if (!chunk) {
     cu_Io_Error err = {
-        .kind = CU_IO_ERROR_KIND_INVALID_INPUT, .errno = Size_Optional_none()};
+        .kind = CU_IO_ERROR_KIND_INVALID_INPUT, .errnum = Size_Optional_none()};
     return cu_Slice_result_error(err);
   }
   if ((unsigned char *)mem.ptr + mem.length == chunk->data + chunk->used) {

--- a/lib/memory/gpallocator.c
+++ b/lib/memory/gpallocator.c
@@ -4,8 +4,7 @@
 #include <string.h>
 
 /* Helper forward declarations */
-static cu_Slice_Result cu_gpa_alloc(
-    void *self, size_t size, size_t alignment);
+static cu_Slice_Result cu_gpa_alloc(void *self, size_t size, size_t alignment);
 static cu_Slice_Result cu_gpa_resize(
     void *self, cu_Slice mem, size_t size, size_t alignment);
 static void cu_gpa_free(void *self, cu_Slice mem);
@@ -106,8 +105,8 @@ static cu_Slice_Result cu_gpa_alloc_small(cu_GPAllocator *gpa, size_t size,
   if (!bucket || bucket->objects.usedCount == bucket->objects.slotCount) {
     bucket = cu_gpa_create_bucket(gpa, obj_size);
     if (!bucket) {
-      cu_Io_Error err = { .kind = CU_IO_ERROR_KIND_OUT_OF_MEMORY,
-                          .errno = Size_Optional_none() };
+      cu_Io_Error err = {.kind = CU_IO_ERROR_KIND_OUT_OF_MEMORY,
+          .errnum = Size_Optional_none()};
       return cu_Slice_result_error(err);
     }
     bucket->prev = gpa->smallBucketTails[idx];
@@ -127,8 +126,8 @@ static cu_Slice_Result cu_gpa_alloc_small(cu_GPAllocator *gpa, size_t size,
     }
   }
   if (slot == bucket->objects.slotCount) {
-    cu_Io_Error err = { .kind = CU_IO_ERROR_KIND_OUT_OF_MEMORY,
-                        .errno = Size_Optional_none() };
+    cu_Io_Error err = {
+        .kind = CU_IO_ERROR_KIND_OUT_OF_MEMORY, .errnum = Size_Optional_none()};
     return cu_Slice_result_error(err);
   }
   cu_Bitmap_set(&bucket->objects.used, slot);
@@ -163,12 +162,11 @@ static cu_Slice_Result cu_gpa_alloc_large(
   return cu_Slice_result_ok(meta->slice);
 }
 
-static cu_Slice_Result cu_gpa_alloc(
-    void *self, size_t size, size_t alignment) {
+static cu_Slice_Result cu_gpa_alloc(void *self, size_t size, size_t alignment) {
   cu_GPAllocator *gpa = (cu_GPAllocator *)self;
   if (size == 0) {
-    cu_Io_Error err = { .kind = CU_IO_ERROR_KIND_INVALID_INPUT,
-                        .errno = Size_Optional_none() };
+    cu_Io_Error err = {
+        .kind = CU_IO_ERROR_KIND_INVALID_INPUT, .errnum = Size_Optional_none()};
     return cu_Slice_result_error(err);
   }
   if (alignment == 0) {
@@ -197,8 +195,8 @@ static cu_Slice_Result cu_gpa_resize(
   }
   if (size == 0) {
     cu_gpa_free(self, mem);
-    cu_Io_Error err = { .kind = CU_IO_ERROR_KIND_INVALID_INPUT,
-                        .errno = Size_Optional_none() };
+    cu_Io_Error err = {
+        .kind = CU_IO_ERROR_KIND_INVALID_INPUT, .errnum = Size_Optional_none()};
     return cu_Slice_result_error(err);
   }
 
@@ -208,8 +206,8 @@ static cu_Slice_Result cu_gpa_resize(
   if (!bucket) {
     struct cu_GPAllocator_LargeAlloc *meta = cu_gpa_find_large(gpa, mem.ptr);
     if (!meta) {
-      cu_Io_Error err = { .kind = CU_IO_ERROR_KIND_INVALID_INPUT,
-                          .errno = Size_Optional_none() };
+      cu_Io_Error err = {.kind = CU_IO_ERROR_KIND_INVALID_INPUT,
+          .errnum = Size_Optional_none()};
       return cu_Slice_result_error(err);
     }
     cu_Slice_Result resized = cu_Allocator_Resize(

--- a/lib/memory/page.c
+++ b/lib/memory/page.c
@@ -20,14 +20,14 @@ static cu_Slice_Result cu_PageAllocator_Alloc(
     void *self, size_t size, size_t alignment) {
   cu_PageAllocator *allocator = (cu_PageAllocator *)self;
   if (size == 0) {
-    cu_Io_Error err = { .kind = CU_IO_ERROR_KIND_INVALID_INPUT,
-                        .errno = Size_Optional_none() };
+    cu_Io_Error err = {
+        .kind = CU_IO_ERROR_KIND_INVALID_INPUT, .errnum = Size_Optional_none()};
     return cu_Slice_result_error(err);
   }
 
   if (alignment == 0 || (alignment & (alignment - 1)) != 0) {
-    cu_Io_Error err = { .kind = CU_IO_ERROR_KIND_INVALID_INPUT,
-                        .errno = Size_Optional_none() };
+    cu_Io_Error err = {
+        .kind = CU_IO_ERROR_KIND_INVALID_INPUT, .errnum = Size_Optional_none()};
     return cu_Slice_result_error(err);
   }
 
@@ -45,16 +45,16 @@ static cu_Slice_Result cu_PageAllocator_Alloc(
   base_ptr = mmap(NULL, overalloc_len, PROT_READ | PROT_WRITE,
       MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
   if (base_ptr == MAP_FAILED) {
-    cu_Io_Error err = { .kind = CU_IO_ERROR_KIND_OUT_OF_MEMORY,
-                        .errno = Size_Optional_none() };
+    cu_Io_Error err = {
+        .kind = CU_IO_ERROR_KIND_OUT_OF_MEMORY, .errnum = Size_Optional_none()};
     return cu_Slice_result_error(err);
   }
 #elif defined(_WIN32)
   base_ptr = VirtualAlloc(
       NULL, overalloc_len, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
   if (base_ptr == NULL) {
-    cu_Io_Error err = { .kind = CU_IO_ERROR_KIND_OUT_OF_MEMORY,
-                        .errno = Size_Optional_none() };
+    cu_Io_Error err = {
+        .kind = CU_IO_ERROR_KIND_OUT_OF_MEMORY, .errnum = Size_Optional_none()};
     return cu_Slice_result_error(err);
   }
 #endif
@@ -81,16 +81,15 @@ static cu_Slice_Result cu_PageAllocator_Alloc(
   }
 #endif
 
-  return cu_Slice_result_ok(
-      cu_Slice_create((void *)aligned_addr, aligned_len));
+  return cu_Slice_result_ok(cu_Slice_create((void *)aligned_addr, aligned_len));
 }
 
 static cu_Slice_Result cu_PageAllocator_Resize(
     void *self, cu_Slice mem, size_t size, size_t alignment) {
   if (size == 0) {
     cu_PageAllocator_Free(self, mem);
-    cu_Io_Error err = { .kind = CU_IO_ERROR_KIND_INVALID_INPUT,
-                        .errno = Size_Optional_none() };
+    cu_Io_Error err = {
+        .kind = CU_IO_ERROR_KIND_INVALID_INPUT, .errnum = Size_Optional_none()};
     return cu_Slice_result_error(err);
   }
 

--- a/lib/memory/slab.c
+++ b/lib/memory/slab.c
@@ -78,7 +78,7 @@ static cu_Slice_Result cu_slab_alloc(
   cu_SlabAllocator *alloc = (cu_SlabAllocator *)self;
   if (size == 0) {
     cu_Io_Error err = {
-        .kind = CU_IO_ERROR_KIND_INVALID_INPUT, .errno = Size_Optional_none()};
+        .kind = CU_IO_ERROR_KIND_INVALID_INPUT, .errnum = Size_Optional_none()};
     return cu_Slice_result_error(err);
   }
   if (alignment == 0) {
@@ -86,7 +86,7 @@ static cu_Slice_Result cu_slab_alloc(
   }
   if (alignment > alloc->slabSize) {
     cu_Io_Error err = {
-        .kind = CU_IO_ERROR_KIND_INVALID_INPUT, .errno = Size_Optional_none()};
+        .kind = CU_IO_ERROR_KIND_INVALID_INPUT, .errnum = Size_Optional_none()};
     return cu_Slice_result_error(err);
   }
 
@@ -115,7 +115,7 @@ static cu_Slice_Result cu_slab_alloc(
     slab = cu_create_slab(alloc, count);
     if (!slab) {
       cu_Io_Error err = {.kind = CU_IO_ERROR_KIND_OUT_OF_MEMORY,
-          .errno = Size_Optional_none()};
+          .errnum = Size_Optional_none()};
       return cu_Slice_result_error(err);
     }
     slab->next = alloc->slabs;
@@ -146,7 +146,7 @@ static cu_Slice_Result cu_slab_resize(
   if (size == 0) {
     cu_slab_free(self, mem);
     cu_Io_Error err = {
-        .kind = CU_IO_ERROR_KIND_INVALID_INPUT, .errno = Size_Optional_none()};
+        .kind = CU_IO_ERROR_KIND_INVALID_INPUT, .errnum = Size_Optional_none()};
     return cu_Slice_result_error(err);
   }
 


### PR DESCRIPTION
## Summary
- avoid `errno` macro expansion in `cu_Io_Error` by renaming the field
- zero-initialize result helpers to avoid padding issues
- adjust all source files to use the new `errnum` field

## Testing
- `python3 meson-1.8.2/meson.py setup build -Dtests=enabled`
- `ninja -C build`
- `ninja -C build test`

------
https://chatgpt.com/codex/tasks/task_e_687a669f0dcc8333b20dee7f7df6af5a