### PR TITLE
Add fixed buffer allocator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ All notable changes to this project will be documented in this file. See [conven
 
 ### Allocator
 
+- add fixed buffer allocator
+
 - use optional for gpa backing - ([c77ca60](https://git.schaub-dev.xyz/cppuniverse/libcute/commit/c77ca60622080cc2688454f5c331889297a7d2d8)) - Fabrice
 - optimize small bucket performance - ([fc40724](https://git.schaub-dev.xyz/cppuniverse/libcute/commit/fc407241090ec0a39ba98901d0786ef3609b1b56)) - Fabrice
 - refine arena and add resize tests - ([67ad00f](https://git.schaub-dev.xyz/cppuniverse/libcute/commit/67ad00f27054ac18def1fe2ea09216c35ff338c9)) - Fabrice

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ memory-features:
 - [x] GP Allocator
 - [x] Arena Allocator
 - [x] Slab Allocator
-- [ ] Fixed Allocator
+- [x] Fixed Allocator
 
 macro-features:
 

--- a/include/cute.h
+++ b/include/cute.h
@@ -11,6 +11,7 @@ extern "C" {
 #include "memory/gpallocator.h"
 #include "memory/page.h"
 #include "memory/slab.h"
+#include "memory/fixedallocator.h"
 
 #include "collection/bitmap.h"
 #include "collection/bitset.h"

--- a/include/memory/fixedallocator.h
+++ b/include/memory/fixedallocator.h
@@ -1,0 +1,23 @@
+#pragma once
+
+/** @file fixedallocator.h Fixed-size buffer allocator. */
+
+#include "memory/allocator.h"
+#include "object/slice.h"
+
+struct cu_FixedAllocator_Header {
+  size_t prev_offset;
+};
+
+/** Runtime state for the fixed allocator. */
+typedef struct {
+  cu_Slice buffer; /**< memory backing */
+  size_t used;    /**< consumed bytes */
+} cu_FixedAllocator;
+
+/** Initialize a fixed allocator using the given buffer. */
+cu_Allocator cu_Allocator_FixedAllocator(
+    cu_FixedAllocator *alloc, cu_Slice buffer);
+
+/** Reset the allocator to reuse the buffer. */
+void cu_FixedAllocator_reset(cu_FixedAllocator *alloc);

--- a/lib/memory/fixedallocator.c
+++ b/lib/memory/fixedallocator.c
@@ -1,0 +1,102 @@
+#include "memory/fixedallocator.h"
+#include "macro.h"
+#include "object/slice.h"
+#include <string.h>
+
+static void cu_fixed_free(void *self, cu_Slice mem);
+
+static cu_Slice_Result cu_fixed_alloc(
+    void *self, size_t size, size_t alignment) {
+  cu_FixedAllocator *alloc = (cu_FixedAllocator *)self;
+  if (size == 0) {
+    cu_Io_Error err = {
+        .kind = CU_IO_ERROR_KIND_INVALID_INPUT, .errnum = Size_Optional_none()};
+    return cu_Slice_result_error(err);
+  }
+  if (alignment == 0) {
+    alignment = 1;
+  }
+
+  const size_t header_size = sizeof(struct cu_FixedAllocator_Header);
+  size_t start = CU_ALIGN_UP(alloc->used + header_size, alignment);
+  if (start + size > alloc->buffer.length) {
+    cu_Io_Error err = {
+        .kind = CU_IO_ERROR_KIND_OUT_OF_MEMORY, .errnum = Size_Optional_none()};
+    return cu_Slice_result_error(err);
+  }
+
+  struct cu_FixedAllocator_Header *hdr =
+      (struct cu_FixedAllocator_Header *)((unsigned char *)alloc->buffer.ptr +
+                                          start - header_size);
+  hdr->prev_offset = alloc->used;
+  alloc->used = start + size;
+  return cu_Slice_result_ok(
+      cu_Slice_create((unsigned char *)alloc->buffer.ptr + start, size));
+}
+
+static cu_Slice_Result cu_fixed_resize(
+    void *self, cu_Slice mem, size_t size, size_t alignment) {
+  cu_FixedAllocator *alloc = (cu_FixedAllocator *)self;
+  if (mem.ptr == NULL) {
+    return cu_fixed_alloc(self, size, alignment);
+  }
+  if (size == 0) {
+    cu_fixed_free(self, mem);
+    cu_Io_Error err = {
+        .kind = CU_IO_ERROR_KIND_INVALID_INPUT, .errnum = Size_Optional_none()};
+    return cu_Slice_result_error(err);
+  }
+
+  const size_t header_size = sizeof(struct cu_FixedAllocator_Header);
+  struct cu_FixedAllocator_Header *hdr =
+      (struct cu_FixedAllocator_Header *)((unsigned char *)mem.ptr -
+                                          header_size);
+  if ((unsigned char *)mem.ptr + mem.length ==
+      (unsigned char *)alloc->buffer.ptr + alloc->used) {
+    size_t avail = alloc->buffer.length - (alloc->used - mem.length);
+    if (size <= mem.length + avail) {
+      alloc->used = (alloc->used - mem.length) + size;
+      return cu_Slice_result_ok(cu_Slice_create(mem.ptr, size));
+    }
+  }
+
+  cu_Slice_Result new_mem = cu_fixed_alloc(self, size, alignment);
+  if (!cu_Slice_result_is_ok(&new_mem)) {
+    return new_mem;
+  }
+  memcpy(new_mem.value.ptr, mem.ptr, mem.length < size ? mem.length : size);
+  // adjust used to release old memory
+  alloc->used = hdr->prev_offset;
+  return new_mem;
+}
+
+static void cu_fixed_free(void *self, cu_Slice mem) {
+  cu_FixedAllocator *alloc = (cu_FixedAllocator *)self;
+  if (mem.ptr == NULL) {
+    return;
+  }
+  const size_t header_size = sizeof(struct cu_FixedAllocator_Header);
+  struct cu_FixedAllocator_Header *hdr =
+      (struct cu_FixedAllocator_Header *)((unsigned char *)mem.ptr -
+                                          header_size);
+  if ((unsigned char *)mem.ptr + mem.length !=
+      (unsigned char *)alloc->buffer.ptr + alloc->used) {
+    return;
+  }
+  alloc->used = hdr->prev_offset;
+}
+
+cu_Allocator cu_Allocator_FixedAllocator(
+    cu_FixedAllocator *alloc, cu_Slice buffer) {
+  alloc->buffer = buffer;
+  alloc->used = 0;
+
+  cu_Allocator a;
+  a.self = alloc;
+  a.allocFn = cu_fixed_alloc;
+  a.resizeFn = cu_fixed_resize;
+  a.freeFn = cu_fixed_free;
+  return a;
+}
+
+void cu_FixedAllocator_reset(cu_FixedAllocator *alloc) { alloc->used = 0; }

--- a/meson.build
+++ b/meson.build
@@ -16,6 +16,7 @@ sources = [
   'lib/memory/arenaallocator.c',
   'lib/memory/gpallocator.c',
   'lib/memory/slab.c',
+  'lib/memory/fixedallocator.c',
   'lib/collection/bitmap.c',
   'lib/hash/hash.c',
   'lib/string/string.c',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -18,6 +18,7 @@ test_files = [
   'test_vector.cpp',
   'test_arena_allocator.cpp',
   'test_fmt.cpp',
+  'test_fixed_allocator.cpp',
 ]
 
 foreach test_file : test_files

--- a/tests/test_fixed_allocator.cpp
+++ b/tests/test_fixed_allocator.cpp
@@ -1,0 +1,35 @@
+#include <gtest/gtest.h>
+#include <string.h>
+extern "C" {
+#include "memory/fixedallocator.h"
+#include "object/slice.h"
+}
+
+TEST(FixedAllocator, Basic) {
+  unsigned char buf[64];
+  cu_FixedAllocator fa;
+  cu_Slice buf_slice = cu_Slice_create(buf, sizeof(buf));
+  cu_Allocator alloc = cu_Allocator_FixedAllocator(&fa, buf_slice);
+
+  cu_Slice_Result a_res = cu_Allocator_Alloc(alloc, 16, 8);
+  ASSERT_TRUE(cu_Slice_result_is_ok(&a_res));
+  cu_Slice a = a_res.value;
+  memset(a.ptr, 0xAA, a.length);
+
+  cu_Allocator_Free(alloc, a);
+  cu_Slice_Result b_res = cu_Allocator_Alloc(alloc, 16, 8);
+  ASSERT_TRUE(cu_Slice_result_is_ok(&b_res));
+  EXPECT_EQ(b_res.value.ptr, a.ptr);
+}
+
+TEST(FixedAllocator, Exhaustion) {
+  unsigned char buf[32];
+  cu_FixedAllocator fa;
+  cu_Slice buf_slice = cu_Slice_create(buf, sizeof(buf));
+  cu_Allocator alloc = cu_Allocator_FixedAllocator(&fa, buf_slice);
+
+  cu_Slice_Result a_res = cu_Allocator_Alloc(alloc, 24, 8);
+  ASSERT_TRUE(cu_Slice_result_is_ok(&a_res));
+  cu_Slice_Result b_res = cu_Allocator_Alloc(alloc, 16, 8);
+  ASSERT_FALSE(cu_Slice_result_is_ok(&b_res));
+}


### PR DESCRIPTION
## Summary
- implement fixed allocator backed by a fixed buffer
- expose the new header through `cute.h`
- integrate implementation with Meson
- add tests for the allocator
- document the feature in README and changelog
- refactor allocator to use `cu_Slice` for buffer management

## Testing
- `meson setup build -Dtests=enabled`
- `ninja -C build`
- `meson test -C build`


------
https://chatgpt.com/codex/tasks/task_e_6883d40c534c83338f5453e387dcf1c8