### PR TITLE
Add WebAssembly platform support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Changelog
+#Changelog
 
 All notable changes to this project will be documented in this file. See [conventional commits](https://www.conventionalcommits.org/) for commit guidelines.
 
@@ -41,6 +41,7 @@ All notable changes to this project will be documented in this file. See [conven
 ### Features
 
 - adds changelog - ([50e2d9a](https://git.schaub-dev.xyz/cppuniverse/libcute/commit/50e2d9abe8f10fd4afcc764475bcb4258ca85edb)) - Fabrice
+- add CU_PLAT_WASM macro and wasm helper header - (unreleased) - Codex
 - adds bitset, starts implementing gpa, fixes macros - ([931d391](https://git.schaub-dev.xyz/cppuniverse/libcute/commit/931d391a6551b651af0f4170bf7e3d2b792b5440)) - Fabrice
 - adds bitmap type - ([d0b722c](https://git.schaub-dev.xyz/cppuniverse/libcute/commit/d0b722cc539b83a4dd722960faba92a604548b6f)) - Fabrice
 - adds faulty vector type - ([05563aa](https://git.schaub-dev.xyz/cppuniverse/libcute/commit/05563aa26c7bf347d5cbd4f4d204d58b81be650f)) - Fabrice

--- a/include/cute.h
+++ b/include/cute.h
@@ -8,10 +8,10 @@ extern "C" {
 
 #include "memory/allocator.h"
 #include "memory/arenaallocator.h"
+#include "memory/fixedallocator.h"
 #include "memory/gpallocator.h"
 #include "memory/page.h"
 #include "memory/slab.h"
-#include "memory/fixedallocator.h"
 
 #include "collection/bitmap.h"
 #include "collection/bitset.h"
@@ -32,6 +32,7 @@ extern "C" {
 #include "io/error.h"
 #include "io/file.h"
 #include "utility.h"
+#include "wasm.h"
 #ifdef __cplusplus
 }
 #endif

--- a/include/macro.h
+++ b/include/macro.h
@@ -43,6 +43,13 @@
 #define CU_PLAT_LINUX 0
 #endif
 
+/* WebAssembly platform detection */
+#if defined(__EMSCRIPTEN__) || defined(__wasm__) || defined(__wasm32__)
+#define CU_PLAT_WASM 1
+#else
+#define CU_PLAT_WASM 0
+#endif
+
 #if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
 #define CU_PLAT_BSD 1
 #else

--- a/include/wasm.h
+++ b/include/wasm.h
@@ -1,0 +1,13 @@
+#pragma once
+
+/** @file wasm.h WebAssembly specific helpers. */
+
+#include "macro.h"
+
+#if CU_PLAT_WASM
+#include <stddef.h>
+
+static inline void cu_wasm_memory_grow(size_t pages) {
+  __builtin_wasm_memory_grow(0, pages);
+}
+#endif


### PR DESCRIPTION
## Summary
- add CU_PLAT_WASM detection macro
- provide wasm-specific helper header
- expose wasm header in umbrella include
- document change in changelog

## Testing
- `python3 meson-1.8.2/meson.py setup build -Dtests=enabled`
- `ninja -C build`
- `meson-1.8.2/meson.py test -C build`


------
https://chatgpt.com/codex/tasks/task_e_6883ed1fb70883338d0a2f9101061f3a