### PR TITLE
Ensure freestanding build compiles on all platforms

### DIFF
--- a/include/memory/allocator.h
+++ b/include/memory/allocator.h
@@ -46,3 +46,6 @@ static inline void cu_Allocator_Free(cu_Allocator allocator, cu_Slice mem) {
 #if !CU_FREESTANDING
 cu_Allocator cu_Allocator_CAllocator(void);
 #endif
+
+/** Allocator that always fails with out-of-memory errors. */
+cu_Allocator cu_Allocator_NullAllocator(void);

--- a/lib/memory/allocator.c
+++ b/lib/memory/allocator.c
@@ -81,3 +81,38 @@ cu_Allocator cu_Allocator_CAllocator(void) {
 #endif // !CU_FREESTANDING
 
 CU_OPTIONAL_IMPL(cu_Allocator, cu_Allocator)
+
+static cu_Slice_Result cu_null_alloc(
+    void *self, size_t size, size_t alignment) {
+  CU_UNUSED(self);
+  CU_UNUSED(size);
+  CU_UNUSED(alignment);
+  cu_Io_Error err = {
+      .kind = CU_IO_ERROR_KIND_OUT_OF_MEMORY, .errnum = Size_Optional_none()};
+  return cu_Slice_result_error(err);
+}
+
+static cu_Slice_Result cu_null_resize(
+    void *self, cu_Slice mem, size_t size, size_t alignment) {
+  CU_UNUSED(self);
+  CU_UNUSED(mem);
+  CU_UNUSED(size);
+  CU_UNUSED(alignment);
+  cu_Io_Error err = {
+      .kind = CU_IO_ERROR_KIND_OUT_OF_MEMORY, .errnum = Size_Optional_none()};
+  return cu_Slice_result_error(err);
+}
+
+static void cu_null_free(void *self, cu_Slice mem) {
+  CU_UNUSED(self);
+  CU_UNUSED(mem);
+}
+
+cu_Allocator cu_Allocator_NullAllocator(void) {
+  cu_Allocator allocator;
+  allocator.self = NULL;
+  allocator.allocFn = cu_null_alloc;
+  allocator.resizeFn = cu_null_resize;
+  allocator.freeFn = cu_null_free;
+  return allocator;
+}

--- a/lib/memory/arenaallocator.c
+++ b/lib/memory/arenaallocator.c
@@ -138,10 +138,12 @@ cu_Allocator cu_Allocator_ArenaAllocator(
   if (cu_Allocator_Optional_is_some(&config.backingAllocator)) {
     arena->backingAllocator = config.backingAllocator.value;
   } else {
-#if CU_PLAT_WASM || CU_FREESTANDING
+#if CU_PLAT_WASM
     arena->backingAllocator = cu_Allocator_WasmAllocator();
-#else
+#elif !CU_FREESTANDING
     arena->backingAllocator = cu_Allocator_CAllocator();
+#else
+    arena->backingAllocator = cu_Allocator_NullAllocator();
 #endif
   }
   arena->chunkSize = config.chunkSize ? config.chunkSize : CU_ARENA_CHUNK_SIZE;

--- a/lib/memory/gpallocator.c
+++ b/lib/memory/gpallocator.c
@@ -296,10 +296,12 @@ cu_Allocator cu_Allocator_GPAllocator(
   if (cu_Allocator_Optional_is_some(&config.backingAllocator)) {
     alloc->backingAllocator = config.backingAllocator.value;
   } else {
-#if CU_PLAT_WASM || CU_FREESTANDING
+#if CU_PLAT_WASM
     alloc->backingAllocator = cu_Allocator_WasmAllocator();
-#else
+#elif !CU_FREESTANDING
     alloc->backingAllocator = cu_Allocator_CAllocator();
+#else
+    alloc->backingAllocator = cu_Allocator_NullAllocator();
 #endif
   }
   alloc->bucketSize =

--- a/lib/memory/slab.c
+++ b/lib/memory/slab.c
@@ -197,10 +197,12 @@ cu_Allocator cu_Allocator_SlabAllocator(
   if (cu_Allocator_Optional_is_some(&cfg.backingAllocator)) {
     alloc->backingAllocator = cfg.backingAllocator.value;
   } else {
-#if CU_PLAT_WASM || CU_FREESTANDING
+#if CU_PLAT_WASM
     alloc->backingAllocator = cu_Allocator_WasmAllocator();
-#else
+#elif !CU_FREESTANDING
     alloc->backingAllocator = cu_Allocator_CAllocator();
+#else
+    alloc->backingAllocator = cu_Allocator_NullAllocator();
 #endif
   }
   alloc->slabs = NULL;


### PR DESCRIPTION
## Summary
- provide a `NullAllocator` for freestanding builds
- use `NullAllocator` when no default allocator is available
- allow building library in freestanding mode even when not targeting WASM

## Testing
- `python3 meson-1.8.2/meson.py setup build -Dfreestanding=enabled --wipe`
- `ninja -C build`

------
https://chatgpt.com/codex/tasks/task_e_6884b159b3c88333bd9f2515220d54f3