### PR TITLE
Add skip list sorted string table test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@ All notable changes to this project will be documented in this file. See [conven
 
 - add ring buffer container - ([5555350](https://git.schaub-dev.xyz/cppuniverse/libcute/commit/55553500bdc85f506de28725cf9816dd939b3f39)) - Fabrice
 - extend list APIs - ([8788373](https://git.schaub-dev.xyz/cppuniverse/libcute/commit/878837377a7c283cfe5b39355b43de0782e9b410)) - Fabrice
+- add skip list container -
+- add skip list sorted string table test -
 
 ### Example
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ collection-features:
       Bitmaps allocate their storage on the heap and are used for larger dynamic sets.
  - [x] linked and doubly linked
 - [x] ring buffer
+- [x] skip list
 
 method-features:
 

--- a/include/collection/skip_list.h
+++ b/include/collection/skip_list.h
@@ -1,0 +1,66 @@
+#pragma once
+
+/** @file skip_list.h Simple skip list map. */
+
+#include "macro.h"
+#include "memory/allocator.h"
+#include "object/optional.h"
+#include "object/result.h"
+#include "utility.h"
+#include <stdbool.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef int (*cu_SkipList_CmpFn)(const void *a, const void *b);
+CU_OPTIONAL_DECL(cu_SkipList_CmpFn, cu_SkipList_CmpFn)
+
+typedef struct cu_SkipList_Node {
+  struct cu_SkipList_Node **forward;
+  size_t level;
+  void *key;
+  void *value;
+} cu_SkipList_Node;
+
+typedef struct {
+  cu_SkipList_Node *head;
+  size_t level;
+  size_t max_level;
+  cu_SkipList_CmpFn cmp;
+  cu_Layout key_layout;
+  cu_Layout value_layout;
+  cu_Allocator allocator;
+} cu_SkipList;
+
+typedef enum {
+  CU_SKIPLIST_ERROR_NONE = 0,
+  CU_SKIPLIST_ERROR_OOM,
+  CU_SKIPLIST_ERROR_INVALID_LAYOUT,
+  CU_SKIPLIST_ERROR_INVALID,
+} cu_SkipList_Error;
+
+CU_RESULT_DECL(cu_SkipList, cu_SkipList, cu_SkipList_Error)
+CU_OPTIONAL_DECL(cu_SkipList_Error, cu_SkipList_Error)
+
+cu_SkipList_Result cu_SkipList_create(cu_Allocator allocator,
+    cu_Layout key_layout, cu_Layout value_layout, size_t max_level,
+    cu_SkipList_CmpFn_Optional cmp);
+
+void cu_SkipList_destroy(cu_SkipList *list);
+
+cu_SkipList_Error_Optional cu_SkipList_insert(
+    cu_SkipList *list, void *key, void *value);
+
+Ptr_Optional cu_SkipList_find(const cu_SkipList *list, const void *key);
+
+cu_SkipList_Error_Optional cu_SkipList_remove(
+    cu_SkipList *list, const void *key);
+
+bool cu_SkipList_iter(const cu_SkipList *list, cu_SkipList_Node **node,
+    void **key, void **value);
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/cute.h
+++ b/include/cute.h
@@ -19,6 +19,7 @@ extern "C" {
 #include "collection/hashmap.h"
 #include "collection/list.h"
 #include "collection/ring_buffer.h"
+#include "collection/skip_list.h"
 #include "collection/vector.h"
 
 #include "hash/hash.h"

--- a/lib/collection/skip_list.c
+++ b/lib/collection/skip_list.c
@@ -1,0 +1,247 @@
+#include "collection/skip_list.h"
+#include "memory/allocator.h"
+#include "utility.h"
+#include <nostd.h>
+#include <stdalign.h>
+
+CU_RESULT_IMPL(cu_SkipList, cu_SkipList, cu_SkipList_Error)
+CU_OPTIONAL_IMPL(cu_SkipList_Error, cu_SkipList_Error)
+CU_OPTIONAL_IMPL(cu_SkipList_CmpFn, cu_SkipList_CmpFn)
+
+static int cu_SkipList_default_cmp(const void *a, const void *b) {
+  const int *ia = (const int *)a;
+  const int *ib = (const int *)b;
+  if (*ia < *ib)
+    return -1;
+  if (*ia > *ib)
+    return 1;
+  return 0;
+}
+
+static uint32_t rng_state = 1;
+static uint32_t rng_next(void) {
+  rng_state = rng_state * 1664525u + 1013904223u;
+  return rng_state;
+}
+
+static size_t cu_SkipList_random_level(const cu_SkipList *list) {
+  size_t lvl = 1;
+  while ((rng_next() & 0xFFFF) < 0x8000 && lvl < list->max_level) {
+    lvl++;
+  }
+  return lvl;
+}
+
+static cu_SkipList_Error_Optional cu_SkipList_alloc_node(cu_SkipList *list,
+    size_t level, void *key, void *value, cu_SkipList_Node **out) {
+  size_t fwd_sz = level * sizeof(cu_SkipList_Node *);
+  size_t node_sz = sizeof(cu_SkipList_Node) + fwd_sz;
+  cu_Slice_Result mem =
+      cu_Allocator_Alloc(list->allocator, node_sz, alignof(cu_SkipList_Node));
+  if (!cu_Slice_result_is_ok(&mem)) {
+    return cu_SkipList_Error_Optional_some(CU_SKIPLIST_ERROR_OOM);
+  }
+  cu_SkipList_Node *node = (cu_SkipList_Node *)mem.value.ptr;
+  node->forward = (cu_SkipList_Node **)((unsigned char *)node + sizeof(*node));
+  node->level = level;
+  for (size_t i = 0; i < level; ++i) {
+    node->forward[i] = NULL;
+  }
+
+  cu_Slice_Result k = cu_Allocator_Alloc(list->allocator,
+      list->key_layout.elem_size, list->key_layout.alignment);
+  if (!cu_Slice_result_is_ok(&k)) {
+    cu_Allocator_Free(list->allocator, mem.value);
+    return cu_SkipList_Error_Optional_some(CU_SKIPLIST_ERROR_OOM);
+  }
+  cu_Memory_memcpy(k.value.ptr, cu_Slice_create(key, list->key_layout.elem_size));
+  node->key = k.value.ptr;
+
+  cu_Slice_Result v = cu_Allocator_Alloc(list->allocator,
+      list->value_layout.elem_size, list->value_layout.alignment);
+  if (!cu_Slice_result_is_ok(&v)) {
+    cu_Allocator_Free(list->allocator, mem.value);
+    cu_Allocator_Free(list->allocator, k.value);
+    return cu_SkipList_Error_Optional_some(CU_SKIPLIST_ERROR_OOM);
+  }
+  cu_Memory_memcpy(v.value.ptr,
+      cu_Slice_create(value, list->value_layout.elem_size));
+  node->value = v.value.ptr;
+
+  *out = node;
+  return cu_SkipList_Error_Optional_none();
+}
+
+cu_SkipList_Result cu_SkipList_create(cu_Allocator allocator,
+    cu_Layout key_layout, cu_Layout value_layout, size_t max_level,
+    cu_SkipList_CmpFn_Optional cmp) {
+  CU_LAYOUT_CHECK(key_layout) {
+    return cu_SkipList_result_error(CU_SKIPLIST_ERROR_INVALID_LAYOUT);
+  }
+  CU_LAYOUT_CHECK(value_layout) {
+    return cu_SkipList_result_error(CU_SKIPLIST_ERROR_INVALID_LAYOUT);
+  }
+  if (max_level == 0) {
+    return cu_SkipList_result_error(CU_SKIPLIST_ERROR_INVALID);
+  }
+
+  size_t head_size = sizeof(cu_SkipList_Node) + max_level * sizeof(cu_SkipList_Node *);
+  cu_Slice_Result mem = cu_Allocator_Alloc(allocator, head_size, alignof(cu_SkipList_Node));
+  if (!cu_Slice_result_is_ok(&mem)) {
+    return cu_SkipList_result_error(CU_SKIPLIST_ERROR_OOM);
+  }
+  cu_SkipList_Node *head = (cu_SkipList_Node *)mem.value.ptr;
+  head->forward = (cu_SkipList_Node **)((unsigned char *)head + sizeof(*head));
+  head->level = max_level;
+  for (size_t i = 0; i < max_level; ++i) {
+    head->forward[i] = NULL;
+  }
+  head->key = NULL;
+  head->value = NULL;
+
+  cu_SkipList list;
+  list.head = head;
+  list.level = 1;
+  list.max_level = max_level;
+  list.cmp = cu_SkipList_default_cmp;
+  if (cu_SkipList_CmpFn_Optional_is_some(&cmp)) {
+    list.cmp = cu_SkipList_CmpFn_Optional_unwrap(&cmp);
+  }
+  list.key_layout = key_layout;
+  list.value_layout = value_layout;
+  list.allocator = allocator;
+  return cu_SkipList_result_ok(list);
+}
+
+void cu_SkipList_destroy(cu_SkipList *list) {
+  if (!list)
+    return;
+  cu_SkipList_Node *node = list->head->forward[0];
+  while (node) {
+    cu_SkipList_Node *next = node->forward[0];
+    cu_Allocator_Free(list->allocator,
+        cu_Slice_create(node->key, list->key_layout.elem_size));
+    cu_Allocator_Free(list->allocator,
+        cu_Slice_create(node->value, list->value_layout.elem_size));
+    cu_Allocator_Free(list->allocator,
+        cu_Slice_create(node, sizeof(cu_SkipList_Node) + node->level * sizeof(cu_SkipList_Node *)));
+    node = next;
+  }
+  cu_Allocator_Free(list->allocator,
+      cu_Slice_create(list->head, sizeof(cu_SkipList_Node) + list->max_level * sizeof(cu_SkipList_Node *)));
+  list->head = NULL;
+  list->level = 0;
+  list->max_level = 0;
+}
+
+cu_SkipList_Error_Optional cu_SkipList_insert(
+    cu_SkipList *list, void *key, void *value) {
+  CU_IF_NULL(list) {
+    return cu_SkipList_Error_Optional_some(CU_SKIPLIST_ERROR_INVALID);
+  }
+  CU_LAYOUT_CHECK(list->key_layout) {
+    return cu_SkipList_Error_Optional_some(CU_SKIPLIST_ERROR_INVALID_LAYOUT);
+  }
+  CU_LAYOUT_CHECK(list->value_layout) {
+    return cu_SkipList_Error_Optional_some(CU_SKIPLIST_ERROR_INVALID_LAYOUT);
+  }
+  cu_SkipList_Node *update[list->max_level];
+  cu_SkipList_Node *x = list->head;
+  for (size_t i = list->level; i-- > 0;) {
+    while (x->forward[i] && list->cmp(x->forward[i]->key, key) < 0) {
+      x = x->forward[i];
+    }
+    update[i] = x;
+  }
+  x = x->forward[0];
+  if (x && list->cmp(x->key, key) == 0) {
+    cu_Memory_memcpy(x->value,
+        cu_Slice_create(value, list->value_layout.elem_size));
+    return cu_SkipList_Error_Optional_none();
+  }
+  size_t lvl = cu_SkipList_random_level(list);
+  if (lvl > list->level) {
+    for (size_t i = list->level; i < lvl; ++i) {
+      update[i] = list->head;
+    }
+    list->level = lvl;
+  }
+  cu_SkipList_Node *node = NULL;
+  cu_SkipList_Error_Optional err =
+      cu_SkipList_alloc_node(list, lvl, key, value, &node);
+  if (cu_SkipList_Error_Optional_is_some(&err)) {
+    return err;
+  }
+  for (size_t i = 0; i < lvl; ++i) {
+    node->forward[i] = update[i]->forward[i];
+    update[i]->forward[i] = node;
+  }
+  return cu_SkipList_Error_Optional_none();
+}
+
+Ptr_Optional cu_SkipList_find(const cu_SkipList *list, const void *key) {
+  CU_IF_NULL(list) { return Ptr_Optional_none(); }
+  cu_SkipList_Node *x = list->head;
+  for (size_t i = list->level; i-- > 0;) {
+    while (x->forward[i] && list->cmp(x->forward[i]->key, key) < 0) {
+      x = x->forward[i];
+    }
+  }
+  x = x->forward[0];
+  if (x && list->cmp(x->key, key) == 0) {
+    return Ptr_Optional_some(x->value);
+  }
+  return Ptr_Optional_none();
+}
+
+cu_SkipList_Error_Optional cu_SkipList_remove(
+    cu_SkipList *list, const void *key) {
+  CU_IF_NULL(list) {
+    return cu_SkipList_Error_Optional_some(CU_SKIPLIST_ERROR_INVALID);
+  }
+  cu_SkipList_Node *update[list->max_level];
+  cu_SkipList_Node *x = list->head;
+  for (size_t i = list->level; i-- > 0;) {
+    while (x->forward[i] && list->cmp(x->forward[i]->key, key) < 0) {
+      x = x->forward[i];
+    }
+    update[i] = x;
+  }
+  x = x->forward[0];
+  if (!x || list->cmp(x->key, key) != 0) {
+    return cu_SkipList_Error_Optional_some(CU_SKIPLIST_ERROR_INVALID);
+  }
+  for (size_t i = 0; i < list->level; ++i) {
+    if (update[i]->forward[i] != x) {
+      break;
+    }
+    update[i]->forward[i] = x->forward[i];
+  }
+  while (list->level > 1 && list->head->forward[list->level - 1] == NULL) {
+    list->level--;
+  }
+  cu_Allocator_Free(list->allocator,
+      cu_Slice_create(x->key, list->key_layout.elem_size));
+  cu_Allocator_Free(list->allocator,
+      cu_Slice_create(x->value, list->value_layout.elem_size));
+  cu_Allocator_Free(list->allocator,
+      cu_Slice_create(x, sizeof(cu_SkipList_Node) + x->level * sizeof(cu_SkipList_Node *)));
+  return cu_SkipList_Error_Optional_none();
+}
+
+bool cu_SkipList_iter(const cu_SkipList *list, cu_SkipList_Node **node,
+    void **key, void **value) {
+  CU_IF_NULL(list) { return false; }
+  CU_IF_NULL(node) { return false; }
+  CU_IF_NULL(key) { return false; }
+  CU_IF_NULL(value) { return false; }
+
+  cu_SkipList_Node *cur = *node ? (*node)->forward[0] : list->head->forward[0];
+  if (!cur) {
+    return false;
+  }
+  *node = cur;
+  *key = cur->key;
+  *value = cur->value;
+  return true;
+}

--- a/meson.build
+++ b/meson.build
@@ -25,6 +25,7 @@ sources = [
   'lib/collection/ring_buffer.c',
   'lib/collection/list.c',
   'lib/collection/dlist.c',
+  'lib/collection/skip_list.c',
   'lib/collection/vector.c',
   'lib/collection/hashmap.c',
   'lib/io/error.c',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -21,6 +21,8 @@ test_files = [
   'test_fmt.cpp',
   'test_fixed_allocator.cpp',
   'test_wasm_allocator.cpp',
+  'test_skip_list.cpp',
+  'test_skip_list_sst.cpp',
 ]
 
 foreach test_file : test_files

--- a/tests/test_skip_list.cpp
+++ b/tests/test_skip_list.cpp
@@ -1,0 +1,93 @@
+#if CU_FREESTANDING
+#include <gtest/gtest.h>
+TEST(SkipList, Unsupported) { SUCCEED(); }
+#else
+extern "C" {
+#include "collection/skip_list.h"
+#include "memory/allocator.h"
+#include "memory/fixedallocator.h"
+#include "memory/gpallocator.h"
+}
+#include <gtest/gtest.h>
+
+static cu_Allocator create_allocator(cu_GPAllocator *gpa) {
+#if CU_FREESTANDING
+  static char buf[32 * 1024];
+  cu_FixedAllocator fa;
+  cu_Allocator backing =
+      cu_Allocator_FixedAllocator(&fa, cu_Slice_create(buf, sizeof(buf)));
+#else
+  cu_PageAllocator page;
+  cu_Allocator backing = cu_Allocator_PageAllocator(&page);
+#endif
+  cu_GPAllocator_Config cfg = {};
+  cfg.bucketSize = CU_GPA_BUCKET_SIZE;
+  cfg.backingAllocator = cu_Allocator_Optional_some(backing);
+  return cu_Allocator_GPAllocator(gpa, cfg);
+}
+
+static int int_cmp(const void *a, const void *b) {
+  int ia = *(const int *)a;
+  int ib = *(const int *)b;
+  return (ia > ib) - (ia < ib);
+}
+
+TEST(SkipList, InsertFindRemove) {
+  cu_GPAllocator gpa;
+  cu_Allocator alloc = create_allocator(&gpa);
+
+  cu_SkipList_Result res = cu_SkipList_create(alloc, CU_LAYOUT(int),
+      CU_LAYOUT(int), 8, cu_SkipList_CmpFn_Optional_some(int_cmp));
+  ASSERT_TRUE(cu_SkipList_result_is_ok(&res));
+  cu_SkipList list = cu_SkipList_result_unwrap(&res);
+
+  for (int i = 0; i < 10; ++i) {
+    cu_SkipList_Error_Optional err = cu_SkipList_insert(&list, &i, &i);
+    ASSERT_TRUE(cu_SkipList_Error_Optional_is_none(&err));
+  }
+
+  for (int i = 0; i < 10; ++i) {
+    Ptr_Optional opt = cu_SkipList_find(&list, &i);
+    ASSERT_TRUE(Ptr_Optional_is_some(&opt));
+    int *v = (int *)Ptr_Optional_unwrap(&opt);
+    EXPECT_EQ(*v, i);
+  }
+
+  for (int i = 0; i < 10; ++i) {
+    cu_SkipList_Error_Optional err = cu_SkipList_remove(&list, &i);
+    ASSERT_TRUE(cu_SkipList_Error_Optional_is_none(&err));
+  }
+  EXPECT_TRUE(cu_SkipList_find(&list, &(int){0}).isSome == false);
+
+  cu_SkipList_destroy(&list);
+  cu_GPAllocator_destroy(&gpa);
+}
+
+TEST(SkipList, Iteration) {
+  cu_GPAllocator gpa;
+  cu_Allocator alloc = create_allocator(&gpa);
+
+  cu_SkipList_Result res = cu_SkipList_create(alloc, CU_LAYOUT(int),
+      CU_LAYOUT(int), 6, cu_SkipList_CmpFn_Optional_some(int_cmp));
+  ASSERT_TRUE(cu_SkipList_result_is_ok(&res));
+  cu_SkipList list = cu_SkipList_result_unwrap(&res);
+
+  int sum = 0;
+  for (int i = 0; i < 5; ++i) {
+    cu_SkipList_insert(&list, &i, &i);
+    sum += i;
+  }
+
+  cu_SkipList_Node *n = NULL;
+  void *k;
+  void *v;
+  int iter_sum = 0;
+  while (cu_SkipList_iter(&list, &n, &k, &v)) {
+    iter_sum += *(int *)v;
+  }
+  EXPECT_EQ(iter_sum, sum);
+
+  cu_SkipList_destroy(&list);
+  cu_GPAllocator_destroy(&gpa);
+}
+#endif

--- a/tests/test_skip_list_sst.cpp
+++ b/tests/test_skip_list_sst.cpp
@@ -1,0 +1,76 @@
+#if CU_FREESTANDING
+#include <gtest/gtest.h>
+TEST(SkipListSST, Unsupported) { SUCCEED(); }
+#else
+extern "C" {
+#include "collection/skip_list.h"
+#include "memory/allocator.h"
+#include "memory/fixedallocator.h"
+#include "memory/gpallocator.h"
+}
+#include <gtest/gtest.h>
+#include <string.h>
+
+static cu_Allocator create_allocator(cu_GPAllocator *gpa) {
+#if CU_FREESTANDING
+  static char buf[32 * 1024];
+  cu_FixedAllocator fa;
+  cu_Allocator backing =
+      cu_Allocator_FixedAllocator(&fa, cu_Slice_create(buf, sizeof(buf)));
+#else
+  cu_PageAllocator page;
+  cu_Allocator backing = cu_Allocator_PageAllocator(&page);
+#endif
+  cu_GPAllocator_Config cfg = {};
+  cfg.bucketSize = CU_GPA_BUCKET_SIZE;
+  cfg.backingAllocator = cu_Allocator_Optional_some(backing);
+  return cu_Allocator_GPAllocator(gpa, cfg);
+}
+
+static int cstring_cmp(const void *a, const void *b) {
+  const char *sa = *(const char *const *)a;
+  const char *sb = *(const char *const *)b;
+  return strcmp(sa, sb);
+}
+
+TEST(SkipListSST, SortedStrings) {
+  cu_GPAllocator gpa;
+  cu_Allocator alloc = create_allocator(&gpa);
+
+  cu_SkipList_Result res = cu_SkipList_create(alloc, CU_LAYOUT(const char *),
+      CU_LAYOUT(const char *), 6, cu_SkipList_CmpFn_Optional_some(cstring_cmp));
+  ASSERT_TRUE(cu_SkipList_result_is_ok(&res));
+  cu_SkipList list = cu_SkipList_result_unwrap(&res);
+
+  const char *keys[] = {"cherry", "apple", "date", "banana", "elderberry"};
+  const char *values[] = {"C", "A", "D", "B", "E"};
+  const char *sorted[] = {"apple", "banana", "cherry", "date", "elderberry"};
+
+  for (int i = 0; i < 5; ++i) {
+    cu_SkipList_Error_Optional err =
+        cu_SkipList_insert(&list, &keys[i], &values[i]);
+    ASSERT_TRUE(cu_SkipList_Error_Optional_is_none(&err));
+  }
+
+  cu_SkipList_Node *n = NULL;
+  void *k;
+  void *v;
+  int idx = 0;
+  while (cu_SkipList_iter(&list, &n, &k, &v)) {
+    const char *kk = *(const char **)k;
+    const char *vv = *(const char **)v;
+    ASSERT_LT(idx, 5);
+    EXPECT_STREQ(kk, sorted[idx]);
+    if (strcmp(kk, "apple") == 0) EXPECT_STREQ(vv, "A");
+    if (strcmp(kk, "banana") == 0) EXPECT_STREQ(vv, "B");
+    if (strcmp(kk, "cherry") == 0) EXPECT_STREQ(vv, "C");
+    if (strcmp(kk, "date") == 0) EXPECT_STREQ(vv, "D");
+    if (strcmp(kk, "elderberry") == 0) EXPECT_STREQ(vv, "E");
+    ++idx;
+  }
+  EXPECT_EQ(idx, 5);
+
+  cu_SkipList_destroy(&list);
+  cu_GPAllocator_destroy(&gpa);
+}
+#endif


### PR DESCRIPTION
## Summary
- add skip list test demonstrating sorted string table usage
- reference new test in the test build setup
- document new test in changelog

## Testing
- `./meson-1.8.2/meson.py setup build -Dtests=enabled`
- `./meson-1.8.2/meson.py compile -C build`
- `./meson-1.8.2/meson.py test -C build --no-rebuild`


------
https://chatgpt.com/codex/tasks/task_e_68871be7e7508333b754c67e59d8f63d