### PR TITLE
allocator api refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ All notable changes to this project will be documented in this file. See [conven
 - some fixes - ([f02ca19](https://git.schaub-dev.xyz/cppuniverse/libcute/commit/f02ca19a63709948575507baaf15f5a745388d72)) - Fabrice
 - adjusted name - ([3e8ec20](https://git.schaub-dev.xyz/cppuniverse/libcute/commit/3e8ec20a5a070f784286564bcf7c80d54144ea78)) - Fabrice
 
+### API
+
+- allocator: accept layout instead of size and alignment
+
 ### Documentation
 
 - expand header documentation - ([22b0a64](https://git.schaub-dev.xyz/cppuniverse/libcute/commit/22b0a6400a4931f70115d747c39ae4ae03c654e7)) - Fabrice

--- a/examples/http/http.c
+++ b/examples/http/http.c
@@ -79,7 +79,7 @@ static void handle_client(cu_HttpServer *server, int fd) {
     }
 
     cu_Slice_Result chunk_res =
-        cu_Allocator_Alloc(server->slab_alloc, CHUNK_SIZE, 1);
+        cu_Allocator_Alloc(server->slab_alloc, cu_Layout_create(CHUNK_SIZE, 1));
     if (!cu_Slice_result_is_ok(&chunk_res)) {
       printf("DEBUG: Failed to allocate chunk\n");
       goto fail;
@@ -94,8 +94,8 @@ static void handle_client(cu_HttpServer *server, int fd) {
     }
 
     // Allocate new buffer
-    cu_Slice_Result resize_res =
-        cu_Allocator_Alloc(server->slab_alloc, total + r + 1, 1);
+    cu_Slice_Result resize_res = cu_Allocator_Alloc(
+        server->slab_alloc, cu_Layout_create(total + r + 1, 1));
     if (!cu_Slice_result_is_ok(&resize_res)) {
       printf("DEBUG: Realloc fallback failed\n");
       cu_Allocator_Free(server->slab_alloc, chunk_res.value);
@@ -165,7 +165,8 @@ static void handle_client(cu_HttpServer *server, int fd) {
   printf("DEBUG: Sending header: %s", header);
   write(fd, header, (size_t)header_len);
 
-  cu_Slice_Result buf_res = cu_Allocator_Alloc(server->slab_alloc, 4096, 1);
+  cu_Slice_Result buf_res =
+      cu_Allocator_Alloc(server->slab_alloc, cu_Layout_create(4096, 1));
   if (!cu_Slice_result_is_ok(&buf_res)) {
     printf("DEBUG: Failed to allocate file buffer\n");
     close(ffd);

--- a/include/memory/allocator.h
+++ b/include/memory/allocator.h
@@ -6,13 +6,13 @@
 
 #include "io/error.h"
 #include "nostd.h"
+#include "utility.h"
 
 /** Allocation function signature. */
-typedef cu_Slice_Result (*cu_Allocator_AllocFunc)(
-    void *self, size_t size, size_t alignment);
+typedef cu_Slice_Result (*cu_Allocator_AllocFunc)(void *self, cu_Layout layout);
 /** Resize function signature. */
 typedef cu_Slice_Result (*cu_Allocator_ResizeFunc)(
-    void *self, cu_Slice mem, size_t size, size_t alignment);
+    void *self, cu_Slice mem, cu_Layout layout);
 /** Free function signature. */
 typedef void (*cu_Allocator_FreeFunc)(void *self, cu_Slice mem);
 
@@ -27,14 +27,14 @@ CU_OPTIONAL_DECL(cu_Allocator, cu_Allocator)
 
 /** Allocate memory using the allocator. */
 static inline cu_Slice_Result cu_Allocator_Alloc(
-    cu_Allocator allocator, size_t size, size_t alignment) {
-  return allocator.allocFn(allocator.self, size, alignment);
+    cu_Allocator allocator, cu_Layout layout) {
+  return allocator.allocFn(allocator.self, layout);
 }
 
 /** Resize a previously allocated block. */
 static inline cu_Slice_Result cu_Allocator_Resize(
-    cu_Allocator allocator, cu_Slice mem, size_t size, size_t alignment) {
-  return allocator.resizeFn(allocator.self, mem, size, alignment);
+    cu_Allocator allocator, cu_Slice mem, cu_Layout layout) {
+  return allocator.resizeFn(allocator.self, mem, layout);
 }
 
 /** Free memory obtained from this allocator. */

--- a/lib/collection/bitmap.c
+++ b/lib/collection/bitmap.c
@@ -10,7 +10,8 @@ cu_Bitmap_Optional cu_Bitmap_create(
 
   size_t size = (bitCount + sizeof(size_t) * 8 - 1) / (sizeof(size_t) * 8);
   cu_Slice_Result mem = cu_Allocator_Alloc(
-      backingAllocator, size * sizeof(size_t), sizeof(size_t));
+      backingAllocator,
+      cu_Layout_create(size * sizeof(size_t), sizeof(size_t)));
   if (!cu_Slice_result_is_ok(&mem)) {
     return cu_Bitmap_Optional_none();
   }

--- a/lib/collection/dlist.c
+++ b/lib/collection/dlist.c
@@ -37,8 +37,8 @@ void cu_DList_destroy(cu_DList *list) {
 static cu_DList_Error_Optional cu_DList_alloc_node(
     cu_DList *list, void *elem, cu_DList_Node **out_node) {
   size_t size = sizeof(cu_DList_Node) + list->layout.elem_size;
-  cu_Slice_Result mem =
-      cu_Allocator_Alloc(list->allocator, size, alignof(cu_DList_Node));
+  cu_Slice_Result mem = cu_Allocator_Alloc(
+      list->allocator, cu_Layout_create(size, alignof(cu_DList_Node)));
   if (!cu_Slice_result_is_ok(&mem)) {
     return cu_DList_Error_Optional_some(CU_DLIST_ERROR_OOM);
   }

--- a/lib/collection/hashmap.c
+++ b/lib/collection/hashmap.c
@@ -69,8 +69,10 @@ static cu_HashMap_Error_Optional cu_HashMap_rehash(
     new_cap = 16;
   }
   new_cap = cu_next_pow2(new_cap);
-  cu_Slice_Result mem = cu_Allocator_Alloc(map->allocator,
-      new_cap * sizeof(cu_HashMap_Bucket), alignof(cu_HashMap_Bucket));
+  cu_Slice_Result mem = cu_Allocator_Alloc(
+      map->allocator,
+      cu_Layout_create(new_cap * sizeof(cu_HashMap_Bucket),
+          alignof(cu_HashMap_Bucket)));
   if (!cu_Slice_result_is_ok(&mem)) {
     return cu_HashMap_Error_Optional_some(CU_HASHMAP_ERROR_OOM);
   }
@@ -119,7 +121,9 @@ cu_HashMap_Result cu_HashMap_create(cu_Allocator allocator,
   }
   cap = cu_next_pow2(cap);
   cu_Slice_Result mem = cu_Allocator_Alloc(
-      allocator, cap * sizeof(cu_HashMap_Bucket), alignof(cu_HashMap_Bucket));
+      allocator,
+      cu_Layout_create(cap * sizeof(cu_HashMap_Bucket),
+          alignof(cu_HashMap_Bucket)));
   if (!cu_Slice_result_is_ok(&mem)) {
     return cu_HashMap_result_error(CU_HASHMAP_ERROR_OOM);
   }
@@ -195,12 +199,16 @@ cu_HashMap_Error_Optional cu_HashMap_insert(
   slot->hash = hash;
 
   cu_Slice_Result key_mem = cu_Allocator_Alloc(
-      map->allocator, map->key_layout.elem_size, map->key_layout.alignment);
+      map->allocator,
+      cu_Layout_create(
+          map->key_layout.elem_size, map->key_layout.alignment));
   if (!cu_Slice_result_is_ok(&key_mem)) {
     return cu_HashMap_Error_Optional_some(CU_HASHMAP_ERROR_OOM);
   }
   cu_Slice_Result val_mem = cu_Allocator_Alloc(
-      map->allocator, map->value_layout.elem_size, map->value_layout.alignment);
+      map->allocator,
+      cu_Layout_create(
+          map->value_layout.elem_size, map->value_layout.alignment));
   if (!cu_Slice_result_is_ok(&val_mem)) {
     cu_Allocator_Free(map->allocator, key_mem.value);
     return cu_HashMap_Error_Optional_some(CU_HASHMAP_ERROR_OOM);

--- a/lib/collection/list.c
+++ b/lib/collection/list.c
@@ -41,8 +41,8 @@ cu_List_Error_Optional cu_List_push_front(cu_List *list, void *elem) {
     return cu_List_Error_Optional_some(CU_LIST_ERROR_INVALID_LAYOUT);
   }
   size_t size = sizeof(cu_List_Node) + list->layout.elem_size;
-  cu_Slice_Result mem =
-      cu_Allocator_Alloc(list->allocator, size, alignof(cu_List_Node));
+  cu_Slice_Result mem = cu_Allocator_Alloc(
+      list->allocator, cu_Layout_create(size, alignof(cu_List_Node)));
   if (!cu_Slice_result_is_ok(&mem)) {
     return cu_List_Error_Optional_some(CU_LIST_ERROR_OOM);
   }
@@ -85,8 +85,8 @@ cu_List_Error_Optional cu_List_insert_after(
   }
 
   size_t size = sizeof(cu_List_Node) + list->layout.elem_size;
-  cu_Slice_Result mem =
-      cu_Allocator_Alloc(list->allocator, size, alignof(cu_List_Node));
+  cu_Slice_Result mem = cu_Allocator_Alloc(
+      list->allocator, cu_Layout_create(size, alignof(cu_List_Node)));
   if (!cu_Slice_result_is_ok(&mem)) {
     return cu_List_Error_Optional_some(CU_LIST_ERROR_OOM);
   }

--- a/lib/collection/ring_buffer.c
+++ b/lib/collection/ring_buffer.c
@@ -14,7 +14,8 @@ cu_RingBuffer_Result cu_RingBuffer_create(
   cu_Slice_Optional data = cu_Slice_Optional_none();
   if (capacity > 0) {
     cu_Slice_Result r = cu_Allocator_Alloc(
-        allocator, capacity * layout.elem_size, layout.alignment);
+        allocator,
+        cu_Layout_create(capacity * layout.elem_size, layout.alignment));
     if (!cu_Slice_result_is_ok(&r)) {
       return cu_RingBuffer_result_error(CU_RINGBUFFER_ERROR_OOM);
     }

--- a/lib/collection/skip_list.c
+++ b/lib/collection/skip_list.c
@@ -36,8 +36,8 @@ static cu_SkipList_Error_Optional cu_SkipList_alloc_node(cu_SkipList *list,
     size_t level, void *key, void *value, cu_SkipList_Node **out) {
   size_t fwd_sz = level * sizeof(cu_SkipList_Node *);
   size_t node_sz = sizeof(cu_SkipList_Node) + fwd_sz;
-  cu_Slice_Result mem =
-      cu_Allocator_Alloc(list->allocator, node_sz, alignof(cu_SkipList_Node));
+  cu_Slice_Result mem = cu_Allocator_Alloc(
+      list->allocator, cu_Layout_create(node_sz, alignof(cu_SkipList_Node)));
   if (!cu_Slice_result_is_ok(&mem)) {
     return cu_SkipList_Error_Optional_some(CU_SKIPLIST_ERROR_OOM);
   }
@@ -49,7 +49,8 @@ static cu_SkipList_Error_Optional cu_SkipList_alloc_node(cu_SkipList *list,
   }
 
   cu_Slice_Result k = cu_Allocator_Alloc(list->allocator,
-      list->key_layout.elem_size, list->key_layout.alignment);
+      cu_Layout_create(list->key_layout.elem_size,
+          list->key_layout.alignment));
   if (!cu_Slice_result_is_ok(&k)) {
     cu_Allocator_Free(list->allocator, mem.value);
     return cu_SkipList_Error_Optional_some(CU_SKIPLIST_ERROR_OOM);
@@ -58,7 +59,8 @@ static cu_SkipList_Error_Optional cu_SkipList_alloc_node(cu_SkipList *list,
   node->key = k.value.ptr;
 
   cu_Slice_Result v = cu_Allocator_Alloc(list->allocator,
-      list->value_layout.elem_size, list->value_layout.alignment);
+      cu_Layout_create(list->value_layout.elem_size,
+          list->value_layout.alignment));
   if (!cu_Slice_result_is_ok(&v)) {
     cu_Allocator_Free(list->allocator, mem.value);
     cu_Allocator_Free(list->allocator, k.value);
@@ -86,7 +88,8 @@ cu_SkipList_Result cu_SkipList_create(cu_Allocator allocator,
   }
 
   size_t head_size = sizeof(cu_SkipList_Node) + max_level * sizeof(cu_SkipList_Node *);
-  cu_Slice_Result mem = cu_Allocator_Alloc(allocator, head_size, alignof(cu_SkipList_Node));
+  cu_Slice_Result mem = cu_Allocator_Alloc(
+      allocator, cu_Layout_create(head_size, alignof(cu_SkipList_Node)));
   if (!cu_Slice_result_is_ok(&mem)) {
     return cu_SkipList_result_error(CU_SKIPLIST_ERROR_OOM);
   }

--- a/lib/collection/vector.c
+++ b/lib/collection/vector.c
@@ -22,8 +22,9 @@ cu_Vector_Result cu_Vector_create(
   if (Size_Optional_is_some(&initial_capacity) &&
       Size_Optional_unwrap(&initial_capacity) > 0) {
     cap = Size_Optional_unwrap(&initial_capacity);
-    cu_Slice_Result r =
-        cu_Allocator_Alloc(allocator, cap * layout.elem_size, layout.alignment);
+    cu_Slice_Result r = cu_Allocator_Alloc(
+        allocator,
+        cu_Layout_create(cap * layout.elem_size, layout.alignment));
     if (!cu_Slice_result_is_ok(&r)) {
       return cu_Vector_result_error(CU_VECTOR_ERROR_OOM);
     }
@@ -65,8 +66,10 @@ static cu_Vector_Error_Optional cu_Vector_set_capacity(
 
   if (cu_Slice_Optional_is_some(&vector->data)) {
     cu_Slice old_data = cu_Slice_Optional_unwrap(&vector->data);
-    cu_Slice_Result new_data = cu_Allocator_Resize(vector->allocator, old_data,
-        capacity * vector->layout.elem_size, vector->layout.alignment);
+    cu_Slice_Result new_data = cu_Allocator_Resize(
+        vector->allocator, old_data,
+        cu_Layout_create(capacity * vector->layout.elem_size,
+            vector->layout.alignment));
 
     if (!cu_Slice_result_is_ok(&new_data)) {
       return cu_Vector_Error_Optional_some(CU_VECTOR_ERROR_OOM);
@@ -77,8 +80,10 @@ static cu_Vector_Error_Optional cu_Vector_set_capacity(
     return cu_Vector_Error_Optional_none();
   }
 
-  cu_Slice_Result new_data_res = cu_Allocator_Alloc(vector->allocator,
-      capacity * vector->layout.elem_size, vector->layout.alignment);
+  cu_Slice_Result new_data_res = cu_Allocator_Alloc(
+      vector->allocator,
+      cu_Layout_create(capacity * vector->layout.elem_size,
+          vector->layout.alignment));
   if (!cu_Slice_result_is_ok(&new_data_res)) {
     return cu_Vector_Error_Optional_some(CU_VECTOR_ERROR_OOM);
   }

--- a/lib/memory/allocator.c
+++ b/lib/memory/allocator.c
@@ -19,17 +19,17 @@ static inline void cu_CAllocator_Free(void *self, cu_Slice mem) {
   free(raw);
 }
 
-static cu_Slice_Result cu_CAllocator_Alloc(
-    void *self, size_t size, size_t alignment) {
+static cu_Slice_Result cu_CAllocator_Alloc(void *self, cu_Layout layout) {
   CU_UNUSED(self);
-  if (size == 0) {
+  if (layout.elem_size == 0) {
     cu_Io_Error err = {
         .kind = CU_IO_ERROR_KIND_INVALID_INPUT, .errnum = Size_Optional_none()};
     return cu_Slice_result_error(err);
   }
 
-  if (alignment < sizeof(void *))
-    alignment = sizeof(void *);
+  size_t size = layout.elem_size;
+  size_t alignment = layout.alignment;
+  if (alignment < sizeof(void *)) alignment = sizeof(void *);
 
   size_t total = size + alignment - 1 + sizeof(void *);
   void *raw = malloc(total);
@@ -48,17 +48,20 @@ static cu_Slice_Result cu_CAllocator_Alloc(
 }
 
 static cu_Slice_Result cu_CAllocator_Resize(
-    void *self, cu_Slice mem, size_t size, size_t alignment) {
+    void *self, cu_Slice mem, cu_Layout layout) {
   CU_UNUSED(self);
-  CU_IF_NULL(mem.ptr) { return cu_CAllocator_Alloc(self, size, alignment); }
-  if (size == 0) {
+  CU_IF_NULL(mem.ptr) { return cu_CAllocator_Alloc(self, layout); }
+  if (layout.elem_size == 0) {
     cu_CAllocator_Free(NULL, mem);
     cu_Io_Error err = {
         .kind = CU_IO_ERROR_KIND_INVALID_INPUT, .errnum = Size_Optional_none()};
     return cu_Slice_result_error(err);
   }
 
-  cu_Slice_Result new_mem = cu_CAllocator_Alloc(self, size, alignment);
+  size_t size = layout.elem_size;
+  size_t alignment = layout.alignment;
+
+  cu_Slice_Result new_mem = cu_CAllocator_Alloc(self, layout);
   if (!cu_Slice_result_is_ok(&new_mem)) {
     return new_mem;
   }
@@ -82,22 +85,19 @@ cu_Allocator cu_Allocator_CAllocator(void) {
 
 CU_OPTIONAL_IMPL(cu_Allocator, cu_Allocator)
 
-static cu_Slice_Result cu_null_alloc(
-    void *self, size_t size, size_t alignment) {
+static cu_Slice_Result cu_null_alloc(void *self, cu_Layout layout) {
   CU_UNUSED(self);
-  CU_UNUSED(size);
-  CU_UNUSED(alignment);
+  CU_UNUSED(layout);
   cu_Io_Error err = {
       .kind = CU_IO_ERROR_KIND_OUT_OF_MEMORY, .errnum = Size_Optional_none()};
   return cu_Slice_result_error(err);
 }
 
 static cu_Slice_Result cu_null_resize(
-    void *self, cu_Slice mem, size_t size, size_t alignment) {
+    void *self, cu_Slice mem, cu_Layout layout) {
   CU_UNUSED(self);
   CU_UNUSED(mem);
-  CU_UNUSED(size);
-  CU_UNUSED(alignment);
+  CU_UNUSED(layout);
   cu_Io_Error err = {
       .kind = CU_IO_ERROR_KIND_OUT_OF_MEMORY, .errnum = Size_Optional_none()};
   return cu_Slice_result_error(err);

--- a/lib/memory/page.c
+++ b/lib/memory/page.c
@@ -14,16 +14,14 @@ static void cu_PageAllocator_Free(void *self, cu_Slice mem) {
   CU_IF_NOT_NULL(mem.ptr) { free(mem.ptr); }
 }
 
-static cu_Slice_Result cu_PageAllocator_Alloc(
-    void *self, size_t size, size_t alignment) {
-  CU_UNUSED(alignment);
+static cu_Slice_Result cu_PageAllocator_Alloc(void *self, cu_Layout layout) {
   cu_PageAllocator *allocator = (cu_PageAllocator *)self;
-  if (size == 0) {
+  if (layout.elem_size == 0) {
     cu_Io_Error err = {
         .kind = CU_IO_ERROR_KIND_INVALID_INPUT, .errnum = Size_Optional_none()};
     return cu_Slice_result_error(err);
   }
-
+  size_t size = layout.elem_size;
   size_t aligned_size = CU_ALIGN_UP(size, allocator->pageSize);
   void *ptr = malloc(aligned_size);
   if (ptr == NULL) {
@@ -35,14 +33,15 @@ static cu_Slice_Result cu_PageAllocator_Alloc(
 }
 
 static cu_Slice_Result cu_PageAllocator_Resize(
-    void *self, cu_Slice mem, size_t size, size_t alignment) {
-  CU_UNUSED(alignment);
-  if (size == 0) {
+    void *self, cu_Slice mem, cu_Layout layout) {
+  if (layout.elem_size == 0) {
     cu_PageAllocator_Free(self, mem);
     cu_Io_Error err = {
         .kind = CU_IO_ERROR_KIND_INVALID_INPUT, .errnum = Size_Optional_none()};
     return cu_Slice_result_error(err);
   }
+
+  size_t size = layout.elem_size;
 
   cu_PageAllocator *allocator = (cu_PageAllocator *)self;
   size_t aligned_size = CU_ALIGN_UP(size, allocator->pageSize);

--- a/lib/memory/slab.c
+++ b/lib/memory/slab.c
@@ -28,9 +28,9 @@ struct cu_SlabAllocator_Slab {
   unsigned char data[];               /**< backing storage */
 };
 
-static cu_Slice_Result cu_slab_alloc(void *self, size_t size, size_t alignment);
+static cu_Slice_Result cu_slab_alloc(void *self, cu_Layout layout);
 static cu_Slice_Result cu_slab_resize(
-    void *self, cu_Slice mem, size_t size, size_t alignment);
+    void *self, cu_Slice mem, cu_Layout layout);
 static void cu_slab_free(void *self, cu_Slice mem);
 
 static unsigned char *cu_slab_data(struct cu_SlabAllocator_Slab *slab) {
@@ -55,8 +55,9 @@ static size_t cu_find_run(struct cu_SlabAllocator_Slab *slab, size_t need) {
 static struct cu_SlabAllocator_Slab *cu_create_slab(
     cu_SlabAllocator *alloc, size_t count) {
   size_t total = sizeof(struct cu_SlabAllocator_Slab) + count * alloc->slabSize;
-  cu_Slice_Result mem =
-      cu_Allocator_Alloc(alloc->backingAllocator, total, alignof(max_align_t));
+  cu_Slice_Result mem = cu_Allocator_Alloc(
+      alloc->backingAllocator,
+      cu_Layout_create(total, alignof(max_align_t)));
   if (!cu_Slice_result_is_ok(&mem)) {
     return NULL;
   }
@@ -74,14 +75,15 @@ static struct cu_SlabAllocator_Slab *cu_create_slab(
   return slab;
 }
 
-static cu_Slice_Result cu_slab_alloc(
-    void *self, size_t size, size_t alignment) {
+static cu_Slice_Result cu_slab_alloc(void *self, cu_Layout layout) {
   cu_SlabAllocator *alloc = (cu_SlabAllocator *)self;
-  if (size == 0) {
+  if (layout.elem_size == 0) {
     cu_Io_Error err = {
         .kind = CU_IO_ERROR_KIND_INVALID_INPUT, .errnum = Size_Optional_none()};
     return cu_Slice_result_error(err);
   }
+  size_t size = layout.elem_size;
+  size_t alignment = layout.alignment;
   if (alignment == 0) {
     alignment = 1;
   }
@@ -146,15 +148,18 @@ static cu_Slice_Result cu_slab_alloc(
 }
 
 static cu_Slice_Result cu_slab_resize(
-    void *self, cu_Slice mem, size_t size, size_t alignment) {
+    void *self, cu_Slice mem, cu_Layout layout) {
   cu_SlabAllocator *alloc = (cu_SlabAllocator *)self;
-  CU_IF_NULL(mem.ptr) { return cu_slab_alloc(self, size, alignment); }
-  if (size == 0) {
+  CU_IF_NULL(mem.ptr) { return cu_slab_alloc(self, layout); }
+  if (layout.elem_size == 0) {
     cu_slab_free(self, mem);
     cu_Io_Error err = {
         .kind = CU_IO_ERROR_KIND_INVALID_INPUT, .errnum = Size_Optional_none()};
     return cu_Slice_result_error(err);
   }
+
+  size_t size = layout.elem_size;
+  size_t alignment = layout.alignment;
 
   struct cu_SlabAllocator_Header *hdr =
       (struct cu_SlabAllocator_Header *)((unsigned char *)mem.ptr -
@@ -167,7 +172,8 @@ static cu_Slice_Result cu_slab_resize(
     return cu_Slice_result_ok(cu_Slice_create(mem.ptr, size));
   }
 
-  cu_Slice_Result new_mem = cu_slab_alloc(self, size, alignment);
+  cu_Slice_Result new_mem =
+      cu_slab_alloc(self, cu_Layout_create(size, alignment));
   if (!cu_Slice_result_is_ok(&new_mem)) {
     return new_mem;
   }

--- a/lib/string/string.c
+++ b/lib/string/string.c
@@ -16,10 +16,12 @@ cu_String cu_String_init(cu_Allocator allocator) {
 static cu_String_Error cu_string_alloc(cu_String *str, size_t cap) {
   cu_Slice_Result mem;
   if (str->data == NULL) {
-    mem = cu_Allocator_Alloc(str->allocator, cap + 1, 1);
+    mem =
+        cu_Allocator_Alloc(str->allocator, cu_Layout_create(cap + 1, 1));
   } else {
     mem = cu_Allocator_Resize(str->allocator,
-        cu_Slice_create(str->data, str->capacity + 1), cap + 1, 1);
+        cu_Slice_create(str->data, str->capacity + 1),
+        cu_Layout_create(cap + 1, 1));
   }
   if (!cu_Slice_result_is_ok(&mem)) {
     return CU_STRING_ERROR_OOM;

--- a/tests/test_allocator.cpp
+++ b/tests/test_allocator.cpp
@@ -18,7 +18,8 @@ TEST(Allocator, GPABasic) {
   cfg.bucketSize = 64;
   cu_Allocator alloc = cu_Allocator_GPAllocator(&gpa, cfg);
 
-  cu_Slice_Result mem_res = cu_Allocator_Alloc(alloc, 32, 8);
+  cu_Slice_Result mem_res =
+      cu_Allocator_Alloc(alloc, cu_Layout_create(32, 8));
   ASSERT_TRUE(cu_Slice_result_is_ok(&mem_res));
   cu_Slice mem = mem_res.value;
   cu_Memory_memset(mem.ptr, 0xAA, mem.length);

--- a/tests/test_arena_allocator.cpp
+++ b/tests/test_arena_allocator.cpp
@@ -39,7 +39,8 @@ TEST(ArenaAllocator, LifoVectors) {
 
   cu_Vector_destroy(&v2);
 
-  cu_Slice_Result reallocation_slice = cu_Allocator_Alloc(alloc, 16, 4);
+  cu_Slice_Result reallocation_slice =
+      cu_Allocator_Alloc(alloc, cu_Layout_create(16, 4));
   ASSERT_TRUE(cu_Slice_result_is_ok(&reallocation_slice));
   EXPECT_EQ(reallocation_slice.value.ptr, v2_ptr);
   cu_Allocator_Free(alloc, reallocation_slice.value);
@@ -59,16 +60,19 @@ TEST(ArenaAllocator, NonLifoAlloc) {
   cfg.backingAllocator = cu_Allocator_Optional_some(fa_alloc);
   cu_Allocator alloc = cu_Allocator_ArenaAllocator(&arena, cfg);
 
-  cu_Slice_Result a_res = cu_Allocator_Alloc(alloc, 16, 8);
+  cu_Slice_Result a_res =
+      cu_Allocator_Alloc(alloc, cu_Layout_create(16, 8));
   ASSERT_TRUE(cu_Slice_result_is_ok(&a_res));
   cu_Slice a = a_res.value;
-  cu_Slice_Result b_res = cu_Allocator_Alloc(alloc, 16, 8);
+  cu_Slice_Result b_res =
+      cu_Allocator_Alloc(alloc, cu_Layout_create(16, 8));
   ASSERT_TRUE(cu_Slice_result_is_ok(&b_res));
   cu_Slice b = b_res.value;
   void *first = a.ptr;
 
   cu_Allocator_Free(alloc, a);
-  cu_Slice_Result c_res = cu_Allocator_Alloc(alloc, 16, 8);
+  cu_Slice_Result c_res =
+      cu_Allocator_Alloc(alloc, cu_Layout_create(16, 8));
   ASSERT_TRUE(cu_Slice_result_is_ok(&c_res));
   cu_Slice c = c_res.value;
   EXPECT_NE(c.ptr, first);
@@ -88,14 +92,16 @@ TEST(ArenaAllocator, ChunkReuseStress) {
   cfg.backingAllocator = cu_Allocator_Optional_some(fa_alloc);
   cu_Allocator alloc = cu_Allocator_ArenaAllocator(&arena, cfg);
 
-  cu_Slice_Result first_res = cu_Allocator_Alloc(alloc, 32, 8);
+  cu_Slice_Result first_res =
+      cu_Allocator_Alloc(alloc, cu_Layout_create(32, 8));
   ASSERT_TRUE(cu_Slice_result_is_ok(&first_res));
   cu_Slice first = first_res.value;
   void *ptr = first.ptr;
   cu_Allocator_Free(alloc, first);
 
   for (int i = 0; i < 1000; ++i) {
-    cu_Slice_Result slice_res = cu_Allocator_Alloc(alloc, 32, 8);
+    cu_Slice_Result slice_res =
+        cu_Allocator_Alloc(alloc, cu_Layout_create(32, 8));
     ASSERT_TRUE(cu_Slice_result_is_ok(&slice_res));
     cu_Slice slice = slice_res.value;
     EXPECT_EQ(slice.ptr, ptr);
@@ -116,7 +122,8 @@ TEST(ArenaAllocator, ReuseOldChunk) {
   cfg.chunkSize = 128;
   cfg.backingAllocator = cu_Allocator_Optional_some(fa_alloc);
   cu_Allocator alloc = cu_Allocator_ArenaAllocator(&arena, cfg);
-  cu_Slice_Result first_res = cu_Allocator_Alloc(alloc, 32, 8);
+  cu_Slice_Result first_res =
+      cu_Allocator_Alloc(alloc, cu_Layout_create(32, 8));
   ASSERT_TRUE(cu_Slice_result_is_ok(&first_res));
   cu_Slice first = first_res.value;
   void *ptr = first.ptr;
@@ -124,14 +131,16 @@ TEST(ArenaAllocator, ReuseOldChunk) {
   cu_Slice_Result blocks_res[20];
   cu_Slice blocks[20];
   for (int i = 0; i < 20; ++i) {
-    blocks_res[i] = cu_Allocator_Alloc(alloc, 112, 8);
+    blocks_res[i] =
+        cu_Allocator_Alloc(alloc, cu_Layout_create(112, 8));
     ASSERT_TRUE(cu_Slice_result_is_ok(&blocks_res[i]));
     blocks[i] = blocks_res[i].value;
   }
 
   cu_Allocator_Free(alloc, first);
 
-  cu_Slice_Result again_res = cu_Allocator_Alloc(alloc, 32, 8);
+  cu_Slice_Result again_res =
+      cu_Allocator_Alloc(alloc, cu_Layout_create(32, 8));
   ASSERT_TRUE(cu_Slice_result_is_ok(&again_res));
   cu_Slice again = again_res.value;
   EXPECT_EQ(again.ptr, ptr);
@@ -154,12 +163,14 @@ TEST(ArenaAllocator, ResizeGrowInPlace) {
   cfg.backingAllocator = cu_Allocator_Optional_some(fa_alloc);
   cu_Allocator alloc = cu_Allocator_ArenaAllocator(&arena, cfg);
 
-  cu_Slice_Result block_res = cu_Allocator_Alloc(alloc, 16, 8);
+  cu_Slice_Result block_res =
+      cu_Allocator_Alloc(alloc, cu_Layout_create(16, 8));
   ASSERT_TRUE(cu_Slice_result_is_ok(&block_res));
   cu_Slice block = block_res.value;
   void *ptr = block.ptr;
 
-  cu_Slice_Result resized = cu_Allocator_Resize(alloc, block, 32, 8);
+  cu_Slice_Result resized =
+      cu_Allocator_Resize(alloc, block, cu_Layout_create(32, 8));
   ASSERT_TRUE(cu_Slice_result_is_ok(&resized));
   EXPECT_EQ(resized.value.ptr, ptr);
 
@@ -178,12 +189,14 @@ TEST(ArenaAllocator, ResizeShrinkInPlace) {
   cfg.backingAllocator = cu_Allocator_Optional_some(fa_alloc);
   cu_Allocator alloc = cu_Allocator_ArenaAllocator(&arena, cfg);
 
-  cu_Slice_Result block_res = cu_Allocator_Alloc(alloc, 32, 8);
+  cu_Slice_Result block_res =
+      cu_Allocator_Alloc(alloc, cu_Layout_create(32, 8));
   ASSERT_TRUE(cu_Slice_result_is_ok(&block_res));
   cu_Slice block = block_res.value;
   void *ptr = block.ptr;
 
-  cu_Slice_Result resized = cu_Allocator_Resize(alloc, block, 16, 8);
+  cu_Slice_Result resized =
+      cu_Allocator_Resize(alloc, block, cu_Layout_create(16, 8));
   ASSERT_TRUE(cu_Slice_result_is_ok(&resized));
   EXPECT_EQ(resized.value.ptr, ptr);
 
@@ -202,15 +215,18 @@ TEST(ArenaAllocator, ResizeAllocNewBlock) {
   cfg.backingAllocator = cu_Allocator_Optional_some(fa_alloc);
   cu_Allocator alloc = cu_Allocator_ArenaAllocator(&arena, cfg);
 
-  cu_Slice_Result a_res = cu_Allocator_Alloc(alloc, 16, 8);
+  cu_Slice_Result a_res =
+      cu_Allocator_Alloc(alloc, cu_Layout_create(16, 8));
   ASSERT_TRUE(cu_Slice_result_is_ok(&a_res));
   cu_Slice a = a_res.value;
-  cu_Slice_Result b_res = cu_Allocator_Alloc(alloc, 16, 8);
+  cu_Slice_Result b_res =
+      cu_Allocator_Alloc(alloc, cu_Layout_create(16, 8));
   ASSERT_TRUE(cu_Slice_result_is_ok(&b_res));
   cu_Slice b = b_res.value;
   void *old_ptr = a.ptr;
 
-  cu_Slice_Result resized = cu_Allocator_Resize(alloc, a, 64, 8);
+  cu_Slice_Result resized =
+      cu_Allocator_Resize(alloc, a, cu_Layout_create(64, 8));
   ASSERT_TRUE(cu_Slice_result_is_ok(&resized));
   EXPECT_NE(resized.value.ptr, old_ptr);
 

--- a/tests/test_fixed_allocator.cpp
+++ b/tests/test_fixed_allocator.cpp
@@ -11,13 +11,15 @@ TEST(FixedAllocator, Basic) {
   cu_Slice buf_slice = cu_Slice_create(buf, sizeof(buf));
   cu_Allocator alloc = cu_Allocator_FixedAllocator(&fa, buf_slice);
 
-  cu_Slice_Result a_res = cu_Allocator_Alloc(alloc, 16, 8);
+  cu_Slice_Result a_res =
+      cu_Allocator_Alloc(alloc, cu_Layout_create(16, 8));
   ASSERT_TRUE(cu_Slice_result_is_ok(&a_res));
   cu_Slice a = a_res.value;
   cu_Memory_memset(a.ptr, 0xAA, a.length);
 
   cu_Allocator_Free(alloc, a);
-  cu_Slice_Result b_res = cu_Allocator_Alloc(alloc, 16, 8);
+  cu_Slice_Result b_res =
+      cu_Allocator_Alloc(alloc, cu_Layout_create(16, 8));
   ASSERT_TRUE(cu_Slice_result_is_ok(&b_res));
   EXPECT_EQ(b_res.value.ptr, a.ptr);
 }
@@ -28,8 +30,10 @@ TEST(FixedAllocator, Exhaustion) {
   cu_Slice buf_slice = cu_Slice_create(buf, sizeof(buf));
   cu_Allocator alloc = cu_Allocator_FixedAllocator(&fa, buf_slice);
 
-  cu_Slice_Result a_res = cu_Allocator_Alloc(alloc, 24, 8);
+  cu_Slice_Result a_res =
+      cu_Allocator_Alloc(alloc, cu_Layout_create(24, 8));
   ASSERT_TRUE(cu_Slice_result_is_ok(&a_res));
-  cu_Slice_Result b_res = cu_Allocator_Alloc(alloc, 16, 8);
+  cu_Slice_Result b_res =
+      cu_Allocator_Alloc(alloc, cu_Layout_create(16, 8));
   ASSERT_FALSE(cu_Slice_result_is_ok(&b_res));
 }

--- a/tests/test_gpa.cpp
+++ b/tests/test_gpa.cpp
@@ -21,7 +21,8 @@ TEST(Allocator, GPALargeAllocFree) {
   cu_Allocator alloc = cu_Allocator_GPAllocator(&gpa, cfg);
 
   const size_t big = 100 * 1024 * 1024; // 100 MiB
-  cu_Slice_Result mem_res = cu_Allocator_Alloc(alloc, big, 16);
+  cu_Slice_Result mem_res =
+      cu_Allocator_Alloc(alloc, cu_Layout_create(big, 16));
   ASSERT_TRUE(cu_Slice_result_is_ok(&mem_res));
   cu_Slice mem = mem_res.value;
   cu_Memory_memset(mem.ptr, 0xCD, mem.length);
@@ -33,7 +34,8 @@ TEST(Allocator, GPALargeAllocFree) {
   std::vector<cu_Slice> blocks;
   blocks.reserve(count);
   for (size_t i = 0; i < count; ++i) {
-    cu_Slice_Result s_res = cu_Allocator_Alloc(alloc, small, 16);
+    cu_Slice_Result s_res =
+        cu_Allocator_Alloc(alloc, cu_Layout_create(small, 16));
     ASSERT_TRUE(cu_Slice_result_is_ok(&s_res));
     cu_Slice s = s_res.value;
     cu_Memory_memset(s.ptr, 0xEF, s.length);
@@ -62,7 +64,8 @@ TEST(Allocator, NormalAllocAndFree) {
   cu_Allocator alloc = cu_Allocator_GPAllocator(&gpa, cfg);
 
   cu_Slice_Result res =
-      cu_Allocator_Alloc(alloc, sizeof(cu_Point), alignof(cu_Point));
+      cu_Allocator_Alloc(alloc,
+          cu_Layout_create(sizeof(cu_Point), alignof(cu_Point)));
   ASSERT_TRUE(cu_Slice_result_is_ok(&res));
 
   cu_Slice mem = res.value;
@@ -91,7 +94,8 @@ TEST(Allocator, DoubleFree) {
   cu_Allocator alloc = cu_Allocator_GPAllocator(&gpa, cfg);
 
   cu_Slice_Result res =
-      cu_Allocator_Alloc(alloc, sizeof(cu_Point), alignof(cu_Point));
+      cu_Allocator_Alloc(alloc,
+          cu_Layout_create(sizeof(cu_Point), alignof(cu_Point)));
   ASSERT_TRUE(cu_Slice_result_is_ok(&res));
 
   cu_Slice mem = res.value;
@@ -119,7 +123,8 @@ TEST(Allocator, Exhaustion) {
   // Allocate a large block
   size_t large_size = 512 * 1024 * 1024; // 100 MiB
   cu_Slice_Result res =
-      cu_Allocator_Alloc(alloc, large_size, alignof(cu_Point));
+      cu_Allocator_Alloc(alloc,
+          cu_Layout_create(large_size, alignof(cu_Point)));
 
   ASSERT_FALSE(cu_Slice_result_is_ok(&res));
   EXPECT_EQ(

--- a/tests/test_page_allocator.cpp
+++ b/tests/test_page_allocator.cpp
@@ -10,7 +10,8 @@ TEST(PageAllocator, Unsupported) { SUCCEED(); }
 TEST(PageAllocator, Basic) {
   cu_PageAllocator palloc;
   cu_Allocator a = cu_Allocator_PageAllocator(&palloc);
-  cu_Slice_Result mem_res = cu_Allocator_Alloc(a, 4096, 4096);
+  cu_Slice_Result mem_res =
+      cu_Allocator_Alloc(a, cu_Layout_create(4096, 4096));
   ASSERT_TRUE(cu_Slice_result_is_ok(&mem_res));
   cu_Slice mem = mem_res.value;
   cu_Memory_memset(mem.ptr, 0, mem.length);

--- a/tests/test_slab_allocator.cpp
+++ b/tests/test_slab_allocator.cpp
@@ -18,10 +18,12 @@ TEST(SlabAllocator, Basic) {
   cfg.backingAllocator = cu_Allocator_Optional_some(fa_alloc);
   cu_Allocator alloc = cu_Allocator_SlabAllocator(&slab, cfg);
 
-  cu_Slice_Result a_res = cu_Allocator_Alloc(alloc, 16, 8);
+  cu_Slice_Result a_res =
+      cu_Allocator_Alloc(alloc, cu_Layout_create(16, 8));
   ASSERT_TRUE(cu_Slice_result_is_ok(&a_res));
   cu_Slice a = a_res.value;
-  cu_Slice_Result b_res = cu_Allocator_Alloc(alloc, 16, 8);
+  cu_Slice_Result b_res =
+      cu_Allocator_Alloc(alloc, cu_Layout_create(16, 8));
   ASSERT_TRUE(cu_Slice_result_is_ok(&b_res));
   cu_Slice b = b_res.value;
   EXPECT_NE(a.ptr, b.ptr);
@@ -40,7 +42,8 @@ TEST(SlabAllocator, BigAllocation) {
   cfg.backingAllocator = cu_Allocator_Optional_some(fa_alloc);
   cu_Allocator alloc = cu_Allocator_SlabAllocator(&slab, cfg);
 
-  cu_Slice_Result big_res = cu_Allocator_Alloc(alloc, 256, 8);
+  cu_Slice_Result big_res =
+      cu_Allocator_Alloc(alloc, cu_Layout_create(256, 8));
   ASSERT_TRUE(cu_Slice_result_is_ok(&big_res));
 
   cu_SlabAllocator_destroy(&slab);
@@ -57,12 +60,14 @@ TEST(SlabAllocator, Resize) {
   cfg.backingAllocator = cu_Allocator_Optional_some(fa_alloc);
   cu_Allocator alloc = cu_Allocator_SlabAllocator(&slab, cfg);
 
-  cu_Slice_Result mem_res = cu_Allocator_Alloc(alloc, 16, 8);
+  cu_Slice_Result mem_res =
+      cu_Allocator_Alloc(alloc, cu_Layout_create(16, 8));
   ASSERT_TRUE(cu_Slice_result_is_ok(&mem_res));
   cu_Slice mem = mem_res.value;
   cu_Memory_memset(mem.ptr, 0xAA, mem.length);
 
-  cu_Slice_Result resized_res = cu_Allocator_Resize(alloc, mem, 128, 8);
+  cu_Slice_Result resized_res =
+      cu_Allocator_Resize(alloc, mem, cu_Layout_create(128, 8));
   ASSERT_TRUE(cu_Slice_result_is_ok(&resized_res));
   EXPECT_EQ(((unsigned char *)resized_res.value.ptr)[0], 0xAA);
 
@@ -81,7 +86,8 @@ TEST(SlabAllocator, ManyAllocations) {
   cu_Allocator alloc = cu_Allocator_SlabAllocator(&slab, cfg);
 
   for (int i = 0; i < 1000; ++i) {
-    cu_Slice_Result s_res = cu_Allocator_Alloc(alloc, 8, 4);
+    cu_Slice_Result s_res =
+        cu_Allocator_Alloc(alloc, cu_Layout_create(8, 4));
     ASSERT_TRUE(cu_Slice_result_is_ok(&s_res));
   }
 
@@ -99,13 +105,15 @@ TEST(SlabAllocator, ReuseFreed) {
   cfg.backingAllocator = cu_Allocator_Optional_some(fa_alloc);
   cu_Allocator alloc = cu_Allocator_SlabAllocator(&slab, cfg);
 
-  cu_Slice_Result a_res = cu_Allocator_Alloc(alloc, 16, 8);
+  cu_Slice_Result a_res =
+      cu_Allocator_Alloc(alloc, cu_Layout_create(16, 8));
   ASSERT_TRUE(cu_Slice_result_is_ok(&a_res));
   cu_Slice a = a_res.value;
   void *ptr = a.ptr;
   cu_Allocator_Free(alloc, a);
 
-  cu_Slice_Result b_res = cu_Allocator_Alloc(alloc, 16, 8);
+  cu_Slice_Result b_res =
+      cu_Allocator_Alloc(alloc, cu_Layout_create(16, 8));
   ASSERT_TRUE(cu_Slice_result_is_ok(&b_res));
   EXPECT_EQ(b_res.value.ptr, ptr);
 
@@ -123,7 +131,8 @@ TEST(SlabAllocator, Alignment) {
   cfg.backingAllocator = cu_Allocator_Optional_some(fa_alloc);
   cu_Allocator alloc = cu_Allocator_SlabAllocator(&slab, cfg);
 
-  cu_Slice_Result res = cu_Allocator_Alloc(alloc, 8, 16);
+  cu_Slice_Result res =
+      cu_Allocator_Alloc(alloc, cu_Layout_create(8, 16));
   ASSERT_TRUE(cu_Slice_result_is_ok(&res));
   EXPECT_EQ((uintptr_t)res.value.ptr % 16, 0u);
 

--- a/tests/test_wasm_allocator.cpp
+++ b/tests/test_wasm_allocator.cpp
@@ -7,7 +7,8 @@ extern "C" {
 #if CU_PLAT_WASM
 TEST(WasmAllocator, Basic) {
   cu_Allocator alloc = cu_Allocator_WasmAllocator();
-  cu_Slice_Result res = cu_Allocator_Alloc(alloc, 64, 8);
+  cu_Slice_Result res =
+      cu_Allocator_Alloc(alloc, cu_Layout_create(64, 8));
   ASSERT_TRUE(cu_Slice_result_is_ok(&res));
   cu_Slice mem = res.value;
   cu_Memory_memset(mem.ptr, 0xAA, mem.length);


### PR DESCRIPTION
## Summary
- modify allocator interface to take `cu_Layout`
- update memory allocators and containers
- update examples and tests
- document change in CHANGELOG

## Testing
- `python3 meson-1.8.2/meson.py setup build -Dtests=enabled`
- `ninja -C build`
- `ninja -C build test` *(fails: 11 tests)*

------
https://chatgpt.com/codex/tasks/task_e_6887456e18f483338fd6187851782eeb