### PR TITLE
Refine optional/result macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project will be documented in this file. See [conven
 - adjusted readme - ([2ff2771](https://git.schaub-dev.xyz/cppuniverse/libcute/commit/2ff2771e982a422c6dac77702b199867f0a94869)) - Fabrice
 - adds changelog - ([18a2468](https://git.schaub-dev.xyz/cppuniverse/libcute/commit/18a24688ea8d9afe6c99cba593fbc1bf2b9207f4)) - Fabrice
 - designing the gpa - ([fe09ec3](https://git.schaub-dev.xyz/cppuniverse/libcute/commit/fe09ec368895dfed564d7664363d68f1f8b55525)) - Fabrice
+- document revised naming scheme - Codex
 - updated changelog - ([fe8eea2](https://git.schaub-dev.xyz/cppuniverse/libcute/commit/fe8eea2dd4ec72a762e4dd7927d9c46a783b4d2e)) - Fabrice
 - clarify bitset and bitmap - ([c212ee4](https://git.schaub-dev.xyz/cppuniverse/libcute/commit/c212ee43b27021c33c70cf24a19d865059b37711)) - Fabrice
 - adds changelog - ([0bc1278](https://git.schaub-dev.xyz/cppuniverse/libcute/commit/0bc1278bbbce8395fe775b69a17c5577cae5f2db)) - Fabrice
@@ -122,6 +123,8 @@ All notable changes to this project will be documented in this file. See [conven
 ### Macro
 
 - add wasm platform macro - ([c3c4cb6](https://git.schaub-dev.xyz/cppuniverse/libcute/commit/c3c4cb66f54a36485732cfc44be3de07ca48d307)) - Fabrice
+- add CU_OPTIONAL_NAME and CU_RESULT_NAME macros - Codex
+- unify result naming and apply CU_*_NAME to function names - Codex
 
 ### Merge
 

--- a/docs/rfcs/0001-naming-conventions.md
+++ b/docs/rfcs/0001-naming-conventions.md
@@ -4,12 +4,16 @@ This document proposes the naming guidelines for libcute. All public symbols mus
 
 ## Prefix
 
-All exported types, functions and global variables begin with `cu_`. The prefix is followed by the subsystem or category name and then the actual identifier.
+All exported identifiers begin with `cu_`. The prefix is followed by a
+`Category` and optionally a `Type` name, both written in `PascalCase`. Function
+methods come last and use `lower_case`.
+
+The pattern is `cu_<Category>_<Type?>_<method>` where `<Type>` is omitted if not applicable.
 
 Examples:
 
-- `cu_Allocator_PageAllocator`
-- `cu_String_create`
+- `cu_File_open`
+- `cu_File_OpenOptions_write`
 
 ## Casing
 

--- a/examples/6502/6502.c
+++ b/examples/6502/6502.c
@@ -34,20 +34,20 @@ static void update_zn(cu_6502 *cpu, uint8_t value) {
 cu_6502_Result cu_6502_create(cu_Allocator allocator) {
   cu_Vector_Result vec_res = cu_Vector_create(
       allocator, CU_LAYOUT(uint8_t), Size_Optional_some(0x10000));
-  if (!cu_Vector_result_is_ok(&vec_res)) {
-    return cu_6502_result_error(CU_6502_ERROR_OOM);
+  if (!cu_Vector_Result_is_ok(&vec_res)) {
+    return cu_6502_Result_error(CU_6502_ERROR_OOM);
   }
   cu_Vector_Error_Optional err = cu_Vector_resize(&vec_res.value, 0x10000);
   if (cu_Vector_Error_Optional_is_some(&err)) {
     cu_Vector_destroy(&vec_res.value);
-    return cu_6502_result_error(CU_6502_ERROR_OOM);
+    return cu_6502_Result_error(CU_6502_ERROR_OOM);
   }
 
   cu_6502 cpu = {0};
   cpu.memory = vec_res.value;
   cpu.sp = 0xFD;
   cpu.status = FLAG_UNUSED;
-  return cu_6502_result_ok(cpu);
+  return cu_6502_Result_ok(cpu);
 }
 
 void cu_6502_destroy(cu_6502 *cpu) { cu_Vector_destroy(&cpu->memory); }

--- a/examples/6502/main.c
+++ b/examples/6502/main.c
@@ -4,7 +4,7 @@
 int main(int argc, char **argv) {
   cu_Allocator alloc = cu_Allocator_CAllocator();
   cu_6502_Result res = cu_6502_create(alloc);
-  if (!cu_6502_result_is_ok(&res)) {
+  if (!cu_6502_Result_is_ok(&res)) {
     return 1;
   }
   cu_6502 cpu = res.value;

--- a/examples/http/http.c
+++ b/examples/http/http.c
@@ -80,7 +80,7 @@ static void handle_client(cu_HttpServer *server, int fd) {
 
     cu_Slice_Result chunk_res =
         cu_Allocator_Alloc(server->slab_alloc, cu_Layout_create(CHUNK_SIZE, 1));
-    if (!cu_Slice_result_is_ok(&chunk_res)) {
+    if (!cu_Slice_Result_is_ok(&chunk_res)) {
       printf("DEBUG: Failed to allocate chunk\n");
       goto fail;
     }
@@ -96,7 +96,7 @@ static void handle_client(cu_HttpServer *server, int fd) {
     // Allocate new buffer
     cu_Slice_Result resize_res = cu_Allocator_Alloc(
         server->slab_alloc, cu_Layout_create(total + r + 1, 1));
-    if (!cu_Slice_result_is_ok(&resize_res)) {
+    if (!cu_Slice_Result_is_ok(&resize_res)) {
       printf("DEBUG: Realloc fallback failed\n");
       cu_Allocator_Free(server->slab_alloc, chunk_res.value);
       goto fail;
@@ -167,7 +167,7 @@ static void handle_client(cu_HttpServer *server, int fd) {
 
   cu_Slice_Result buf_res =
       cu_Allocator_Alloc(server->slab_alloc, cu_Layout_create(4096, 1));
-  if (!cu_Slice_result_is_ok(&buf_res)) {
+  if (!cu_Slice_Result_is_ok(&buf_res)) {
     printf("DEBUG: Failed to allocate file buffer\n");
     close(ffd);
     goto fail;
@@ -201,14 +201,14 @@ cu_HttpServer_Result cu_HttpServer_create(
     cu_Allocator allocator, uint16_t port) {
   cu_Vector_Result vec_res =
       cu_Vector_create(allocator, CU_LAYOUT(int), Size_Optional_some(16));
-  if (!cu_Vector_result_is_ok(&vec_res)) {
-    return cu_HttpServer_result_error(CU_HTTP_ERROR_EPOLL);
+  if (!cu_Vector_Result_is_ok(&vec_res)) {
+    return cu_HttpServer_Result_error(CU_HTTP_ERROR_EPOLL);
   }
 
   int sfd = socket(AF_INET, SOCK_STREAM, 0);
   if (sfd < 0) {
     cu_Vector_destroy(&vec_res.value);
-    return cu_HttpServer_result_error(CU_HTTP_ERROR_SOCKET);
+    return cu_HttpServer_Result_error(CU_HTTP_ERROR_SOCKET);
   }
   set_nonblocking(sfd);
 
@@ -221,19 +221,19 @@ cu_HttpServer_Result cu_HttpServer_create(
   if (bind(sfd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
     close(sfd);
     cu_Vector_destroy(&vec_res.value);
-    return cu_HttpServer_result_error(CU_HTTP_ERROR_SOCKET);
+    return cu_HttpServer_Result_error(CU_HTTP_ERROR_SOCKET);
   }
   if (listen(sfd, 16) < 0) {
     close(sfd);
     cu_Vector_destroy(&vec_res.value);
-    return cu_HttpServer_result_error(CU_HTTP_ERROR_SOCKET);
+    return cu_HttpServer_Result_error(CU_HTTP_ERROR_SOCKET);
   }
 
   int epfd = epoll_create1(0);
   if (epfd < 0) {
     close(sfd);
     cu_Vector_destroy(&vec_res.value);
-    return cu_HttpServer_result_error(CU_HTTP_ERROR_EPOLL);
+    return cu_HttpServer_Result_error(CU_HTTP_ERROR_EPOLL);
   }
   struct epoll_event ev = {0};
   ev.events = EPOLLIN;
@@ -250,7 +250,7 @@ cu_HttpServer_Result cu_HttpServer_create(
   server.slab_alloc = cu_Allocator_SlabAllocator(&server.slab, scfg);
 
   printf("DEBUG: HTTP server created on port %d\n", port);
-  return cu_HttpServer_result_ok(server);
+  return cu_HttpServer_Result_ok(server);
 }
 
 void cu_HttpServer_destroy(cu_HttpServer *server) {

--- a/examples/http/main.c
+++ b/examples/http/main.c
@@ -8,7 +8,7 @@ int main(int argc, char **argv) {
   }
   cu_Allocator alloc = cu_Allocator_CAllocator();
   cu_HttpServer_Result res = cu_HttpServer_create(alloc, port);
-  if (!cu_HttpServer_result_is_ok(&res)) {
+  if (!cu_HttpServer_Result_is_ok(&res)) {
     return 1;
   }
   cu_HttpServer server = res.value;

--- a/include/macro.h
+++ b/include/macro.h
@@ -2,8 +2,6 @@
 
 /** @file macro.h Common utility macros. */
 
-#include <nostd.h>
-
 /** Execute the following block if @p expr is NULL. */
 #define CU_IF_NULL(expr) if ((expr) == NULL)
 /** Execute the following block if @p expr is not NULL. */
@@ -19,6 +17,12 @@
 #define CU_ARRAY_LEN(arr) (sizeof(arr) / sizeof((arr)[0]))
 /** Create a bit mask with bit @p x set. */
 #define CU_BIT(x) (1u << (x))
+
+/** Concatenate two tokens after expanding them. */
+#define CU_CONCAT_(a, b) a##b
+#define CU_CONCAT(a, b) CU_CONCAT_(a, b)
+
+#include <nostd.h>
 /** Platform detection macros */
 #if defined(_WIN32) || defined(_WIN64)
 #define CU_PLAT_WINDOWS 1

--- a/include/object/optional.h
+++ b/include/object/optional.h
@@ -8,48 +8,53 @@
 #include "macro.h"
 #include <nostd.h>
 
+/** Build the concrete optional type name for a category. */
+#define CU_OPTIONAL_NAME(NAME) NAME##_Optional
+/** Construct an optional helper function name. */
+#define CU_OPTIONAL_FN(NAME, SUFFIX) CU_CONCAT(CU_OPTIONAL_NAME(NAME), SUFFIX)
+
 /** Declare optional helper functions for a given type. */
 #define CU_OPTIONAL_HEADER(NAME, T)                                            \
-  NAME##_Optional NAME##_Optional_some(T value);                               \
-  NAME##_Optional NAME##_Optional_none(void);                                  \
-  bool NAME##_Optional_is_some(const NAME##_Optional *opt);                    \
-  bool NAME##_Optional_is_none(const NAME##_Optional *opt);                    \
-  T NAME##_Optional_unwrap(NAME##_Optional *opt);
+  CU_OPTIONAL_NAME(NAME) CU_OPTIONAL_FN(NAME, _some)(T value);                \
+  CU_OPTIONAL_NAME(NAME) CU_OPTIONAL_FN(NAME, _none)(void);                   \
+  bool CU_OPTIONAL_FN(NAME, _is_some)(const CU_OPTIONAL_NAME(NAME) * opt);    \
+  bool CU_OPTIONAL_FN(NAME, _is_none)(const CU_OPTIONAL_NAME(NAME) * opt);    \
+  T CU_OPTIONAL_FN(NAME, _unwrap)(CU_OPTIONAL_NAME(NAME) * opt);
 
 /** Declare the optional struct and associated functions. */
 #define CU_OPTIONAL_DECL(NAME, T)                                              \
   typedef struct {                                                             \
     T value;                                                                   \
     bool isSome;                                                               \
-  } NAME##_Optional;                                                           \
+  } CU_OPTIONAL_NAME(NAME);                                                    \
   CU_OPTIONAL_HEADER(NAME, T)
 
 /** Define the implementation of the optional helpers. */
 #define CU_OPTIONAL_IMPL(NAME, T)                                              \
-  NAME##_Optional NAME##_Optional_some(T value) {                              \
-    NAME##_Optional opt;                                                      \
-    cu_Memory_memset(&opt, 0, sizeof(opt));                                   \
+  CU_OPTIONAL_NAME(NAME) CU_OPTIONAL_FN(NAME, _some)(T value) {               \
+    CU_OPTIONAL_NAME(NAME) opt;                                                \
+    cu_Memory_memset(&opt, 0, sizeof(opt));                                    \
     opt.value = value;                                                         \
     opt.isSome = true;                                                         \
     return opt;                                                                \
   }                                                                            \
                                                                                \
-  NAME##_Optional NAME##_Optional_none(void) {                                 \
-    NAME##_Optional opt;                                                      \
-    cu_Memory_memset(&opt, 0, sizeof(opt));                                   \
+  CU_OPTIONAL_NAME(NAME) CU_OPTIONAL_FN(NAME, _none)(void) {                  \
+    CU_OPTIONAL_NAME(NAME) opt;                                                \
+    cu_Memory_memset(&opt, 0, sizeof(opt));                                    \
     opt.isSome = false;                                                        \
     return opt;                                                                \
   }                                                                            \
                                                                                \
-  bool NAME##_Optional_is_some(const NAME##_Optional *opt) {                   \
+  bool CU_OPTIONAL_FN(NAME, _is_some)(const CU_OPTIONAL_NAME(NAME) * opt) {    \
     return opt->isSome;                                                        \
   }                                                                            \
                                                                                \
-  bool NAME##_Optional_is_none(const NAME##_Optional *opt) {                   \
+  bool CU_OPTIONAL_FN(NAME, _is_none)(const CU_OPTIONAL_NAME(NAME) * opt) {    \
     return !opt->isSome;                                                       \
   }                                                                            \
                                                                                \
-  T NAME##_Optional_unwrap(NAME##_Optional *opt) {                             \
+  T CU_OPTIONAL_FN(NAME, _unwrap)(CU_OPTIONAL_NAME(NAME) * opt) {              \
     if (!opt->isSome) {                                                        \
       CU_DIE("Attempted to unwrap a None optional");                           \
     }                                                                          \

--- a/include/object/result.h
+++ b/include/object/result.h
@@ -6,13 +6,18 @@
 
 #include "macro.h"
 
+/** Build the concrete result type name for a category. */
+#define CU_RESULT_NAME(NAME) NAME##_Result
+/** Construct a result helper function name. */
+#define CU_RESULT_FN(NAME, SUFFIX) CU_CONCAT(CU_RESULT_NAME(NAME), SUFFIX)
+
 /** Declare result helper functions for a given type. */
 #define CU_RESULT_HEADER(NAME, T, E)                                           \
-  NAME##_Result NAME##_result_ok(T value);                                     \
-  NAME##_Result NAME##_result_error(E error);                                  \
-  bool NAME##_result_is_ok(NAME##_Result *result);                             \
-  T NAME##_result_unwrap(NAME##_Result *result);                               \
-  E NAME##_result_unwrap_error(NAME##_Result *result);
+  CU_RESULT_NAME(NAME) CU_RESULT_FN(NAME, _ok)(T value);                      \
+  CU_RESULT_NAME(NAME) CU_RESULT_FN(NAME, _error)(E error);                   \
+  bool CU_RESULT_FN(NAME, _is_ok)(CU_RESULT_NAME(NAME) * result);             \
+  T CU_RESULT_FN(NAME, _unwrap)(CU_RESULT_NAME(NAME) * result);               \
+  E CU_RESULT_FN(NAME, _unwrap_error)(CU_RESULT_NAME(NAME) * result);
 
 /** Declare the typed result struct and its helpers. */
 #define CU_RESULT_DECL(NAME, T, E)                                             \
@@ -22,35 +27,37 @@
       E error;                                                                 \
     };                                                                         \
     bool isOk;                                                                 \
-  } NAME##_Result;                                                             \
+  } CU_RESULT_NAME(NAME);                                                      \
   CU_RESULT_HEADER(NAME, T, E)
 
 /** Implement the typed result helpers. */
 #define CU_RESULT_IMPL(NAME, T, E)                                             \
-  NAME##_Result NAME##_result_ok(T value) {                                    \
-    NAME##_Result result = {0};                                                \
+  CU_RESULT_NAME(NAME) CU_RESULT_FN(NAME, _ok)(T value) {                     \
+    CU_RESULT_NAME(NAME) result = {0};                                         \
     result.value = value;                                                      \
     result.isOk = true;                                                        \
     return result;                                                             \
   }                                                                            \
                                                                                \
-  NAME##_Result NAME##_result_error(E error) {                                 \
-    NAME##_Result result = {0};                                                \
+  CU_RESULT_NAME(NAME) CU_RESULT_FN(NAME, _error)(E error) {                  \
+    CU_RESULT_NAME(NAME) result = {0};                                         \
     result.error = error;                                                      \
     result.isOk = false;                                                       \
     return result;                                                             \
   }                                                                            \
                                                                                \
-  bool NAME##_result_is_ok(NAME##_Result *result) { return result->isOk; }     \
+  bool CU_RESULT_FN(NAME, _is_ok)(CU_RESULT_NAME(NAME) * result) {             \
+    return result->isOk;                                                       \
+  }                                                                            \
                                                                                \
-  T NAME##_result_unwrap(NAME##_Result *result) {                              \
+  T CU_RESULT_FN(NAME, _unwrap)(CU_RESULT_NAME(NAME) * result) {               \
     if (!result->isOk) {                                                       \
       CU_DIE("Attempted to unwrap an error result");                           \
     }                                                                          \
     return result->value;                                                      \
   }                                                                            \
                                                                                \
-  E NAME##_result_unwrap_error(NAME##_Result *result) {                        \
+  E CU_RESULT_FN(NAME, _unwrap_error)(CU_RESULT_NAME(NAME) * result) {         \
     if (result->isOk) {                                                        \
       CU_DIE("Attempted to unwrap an ok result as error");                     \
     }                                                                          \

--- a/lib/collection/bitmap.c
+++ b/lib/collection/bitmap.c
@@ -12,7 +12,7 @@ cu_Bitmap_Optional cu_Bitmap_create(
   cu_Slice_Result mem = cu_Allocator_Alloc(
       backingAllocator,
       cu_Layout_create(size * sizeof(size_t), sizeof(size_t)));
-  if (!cu_Slice_result_is_ok(&mem)) {
+  if (!cu_Slice_Result_is_ok(&mem)) {
     return cu_Bitmap_Optional_none();
   }
 

--- a/lib/collection/dlist.c
+++ b/lib/collection/dlist.c
@@ -7,7 +7,7 @@ CU_OPTIONAL_IMPL(cu_DList_Error, cu_DList_Error)
 
 cu_DList_Result cu_DList_create(cu_Allocator allocator, cu_Layout layout) {
   CU_LAYOUT_CHECK(layout) {
-    return cu_DList_result_error(CU_DLIST_ERROR_INVALID_LAYOUT);
+    return cu_DList_Result_error(CU_DLIST_ERROR_INVALID_LAYOUT);
   }
   cu_DList list = {0};
   list.head = NULL;
@@ -15,7 +15,7 @@ cu_DList_Result cu_DList_create(cu_Allocator allocator, cu_Layout layout) {
   list.length = 0;
   list.layout = layout;
   list.allocator = allocator;
-  return cu_DList_result_ok(list);
+  return cu_DList_Result_ok(list);
 }
 
 void cu_DList_destroy(cu_DList *list) {
@@ -39,7 +39,7 @@ static cu_DList_Error_Optional cu_DList_alloc_node(
   size_t size = sizeof(cu_DList_Node) + list->layout.elem_size;
   cu_Slice_Result mem = cu_Allocator_Alloc(
       list->allocator, cu_Layout_create(size, alignof(cu_DList_Node)));
-  if (!cu_Slice_result_is_ok(&mem)) {
+  if (!cu_Slice_Result_is_ok(&mem)) {
     return cu_DList_Error_Optional_some(CU_DLIST_ERROR_OOM);
   }
   cu_DList_Node *node = (cu_DList_Node *)mem.value.ptr;

--- a/lib/collection/hashmap.c
+++ b/lib/collection/hashmap.c
@@ -73,7 +73,7 @@ static cu_HashMap_Error_Optional cu_HashMap_rehash(
       map->allocator,
       cu_Layout_create(new_cap * sizeof(cu_HashMap_Bucket),
           alignof(cu_HashMap_Bucket)));
-  if (!cu_Slice_result_is_ok(&mem)) {
+  if (!cu_Slice_Result_is_ok(&mem)) {
     return cu_HashMap_Error_Optional_some(CU_HASHMAP_ERROR_OOM);
   }
   cu_HashMap_Bucket *new_buckets = (cu_HashMap_Bucket *)mem.value.ptr;
@@ -110,10 +110,10 @@ cu_HashMap_Result cu_HashMap_create(cu_Allocator allocator,
     Size_Optional initial_capacity, cu_HashMap_HashFn_Optional hash_fn,
     cu_HashMap_EqualsFn_Optional equals_fn) {
   CU_LAYOUT_CHECK(key_layout) {
-    return cu_HashMap_result_error(CU_HASHMAP_ERROR_INVALID_LAYOUT);
+    return cu_HashMap_Result_error(CU_HASHMAP_ERROR_INVALID_LAYOUT);
   }
   CU_LAYOUT_CHECK(value_layout) {
-    return cu_HashMap_result_error(CU_HASHMAP_ERROR_INVALID_LAYOUT);
+    return cu_HashMap_Result_error(CU_HASHMAP_ERROR_INVALID_LAYOUT);
   }
   size_t cap = 16;
   if (Size_Optional_is_some(&initial_capacity)) {
@@ -124,8 +124,8 @@ cu_HashMap_Result cu_HashMap_create(cu_Allocator allocator,
       allocator,
       cu_Layout_create(cap * sizeof(cu_HashMap_Bucket),
           alignof(cu_HashMap_Bucket)));
-  if (!cu_Slice_result_is_ok(&mem)) {
-    return cu_HashMap_result_error(CU_HASHMAP_ERROR_OOM);
+  if (!cu_Slice_Result_is_ok(&mem)) {
+    return cu_HashMap_Result_error(CU_HASHMAP_ERROR_OOM);
   }
   cu_HashMap_Bucket *buckets = (cu_HashMap_Bucket *)mem.value.ptr;
   cu_Memory_memset(buckets, 0, cap * sizeof(cu_HashMap_Bucket));
@@ -146,7 +146,7 @@ cu_HashMap_Result cu_HashMap_create(cu_Allocator allocator,
   if (cu_HashMap_EqualsFn_Optional_is_some(&equals_fn)) {
     map.equals_fn = cu_HashMap_EqualsFn_Optional_unwrap(&equals_fn);
   }
-  return cu_HashMap_result_ok(map);
+  return cu_HashMap_Result_ok(map);
 }
 
 void cu_HashMap_destroy(cu_HashMap *map) {
@@ -202,14 +202,14 @@ cu_HashMap_Error_Optional cu_HashMap_insert(
       map->allocator,
       cu_Layout_create(
           map->key_layout.elem_size, map->key_layout.alignment));
-  if (!cu_Slice_result_is_ok(&key_mem)) {
+  if (!cu_Slice_Result_is_ok(&key_mem)) {
     return cu_HashMap_Error_Optional_some(CU_HASHMAP_ERROR_OOM);
   }
   cu_Slice_Result val_mem = cu_Allocator_Alloc(
       map->allocator,
       cu_Layout_create(
           map->value_layout.elem_size, map->value_layout.alignment));
-  if (!cu_Slice_result_is_ok(&val_mem)) {
+  if (!cu_Slice_Result_is_ok(&val_mem)) {
     cu_Allocator_Free(map->allocator, key_mem.value);
     return cu_HashMap_Error_Optional_some(CU_HASHMAP_ERROR_OOM);
   }

--- a/lib/collection/list.c
+++ b/lib/collection/list.c
@@ -7,7 +7,7 @@ CU_OPTIONAL_IMPL(cu_List_Error, cu_List_Error)
 
 cu_List_Result cu_List_create(cu_Allocator allocator, cu_Layout layout) {
   CU_LAYOUT_CHECK(layout) {
-    return cu_List_result_error(CU_LIST_ERROR_INVALID_LAYOUT);
+    return cu_List_Result_error(CU_LIST_ERROR_INVALID_LAYOUT);
   }
 
   cu_List list = {0};
@@ -15,7 +15,7 @@ cu_List_Result cu_List_create(cu_Allocator allocator, cu_Layout layout) {
   list.length = 0;
   list.layout = layout;
   list.allocator = allocator;
-  return cu_List_result_ok(list);
+  return cu_List_Result_ok(list);
 }
 
 void cu_List_destroy(cu_List *list) {
@@ -43,7 +43,7 @@ cu_List_Error_Optional cu_List_push_front(cu_List *list, void *elem) {
   size_t size = sizeof(cu_List_Node) + list->layout.elem_size;
   cu_Slice_Result mem = cu_Allocator_Alloc(
       list->allocator, cu_Layout_create(size, alignof(cu_List_Node)));
-  if (!cu_Slice_result_is_ok(&mem)) {
+  if (!cu_Slice_Result_is_ok(&mem)) {
     return cu_List_Error_Optional_some(CU_LIST_ERROR_OOM);
   }
   cu_List_Node *node = (cu_List_Node *)mem.value.ptr;
@@ -87,7 +87,7 @@ cu_List_Error_Optional cu_List_insert_after(
   size_t size = sizeof(cu_List_Node) + list->layout.elem_size;
   cu_Slice_Result mem = cu_Allocator_Alloc(
       list->allocator, cu_Layout_create(size, alignof(cu_List_Node)));
-  if (!cu_Slice_result_is_ok(&mem)) {
+  if (!cu_Slice_Result_is_ok(&mem)) {
     return cu_List_Error_Optional_some(CU_LIST_ERROR_OOM);
   }
 

--- a/lib/collection/ring_buffer.c
+++ b/lib/collection/ring_buffer.c
@@ -8,7 +8,7 @@ CU_OPTIONAL_IMPL(cu_RingBuffer_Error, cu_RingBuffer_Error)
 cu_RingBuffer_Result cu_RingBuffer_create(
     cu_Allocator allocator, cu_Layout layout, size_t capacity) {
   CU_LAYOUT_CHECK(layout) {
-    return cu_RingBuffer_result_error(CU_RINGBUFFER_ERROR_INVALID_LAYOUT);
+    return cu_RingBuffer_Result_error(CU_RINGBUFFER_ERROR_INVALID_LAYOUT);
   }
 
   cu_Slice_Optional data = cu_Slice_Optional_none();
@@ -16,8 +16,8 @@ cu_RingBuffer_Result cu_RingBuffer_create(
     cu_Slice_Result r = cu_Allocator_Alloc(
         allocator,
         cu_Layout_create(capacity * layout.elem_size, layout.alignment));
-    if (!cu_Slice_result_is_ok(&r)) {
-      return cu_RingBuffer_result_error(CU_RINGBUFFER_ERROR_OOM);
+    if (!cu_Slice_Result_is_ok(&r)) {
+      return cu_RingBuffer_Result_error(CU_RINGBUFFER_ERROR_OOM);
     }
     data = cu_Slice_Optional_some(r.value);
   }
@@ -30,7 +30,7 @@ cu_RingBuffer_Result cu_RingBuffer_create(
   rb.layout = layout;
   rb.allocator = allocator;
 
-  return cu_RingBuffer_result_ok(rb);
+  return cu_RingBuffer_Result_ok(rb);
 }
 
 void cu_RingBuffer_destroy(cu_RingBuffer *rb) {

--- a/lib/collection/skip_list.c
+++ b/lib/collection/skip_list.c
@@ -38,7 +38,7 @@ static cu_SkipList_Error_Optional cu_SkipList_alloc_node(cu_SkipList *list,
   size_t node_sz = sizeof(cu_SkipList_Node) + fwd_sz;
   cu_Slice_Result mem = cu_Allocator_Alloc(
       list->allocator, cu_Layout_create(node_sz, alignof(cu_SkipList_Node)));
-  if (!cu_Slice_result_is_ok(&mem)) {
+  if (!cu_Slice_Result_is_ok(&mem)) {
     return cu_SkipList_Error_Optional_some(CU_SKIPLIST_ERROR_OOM);
   }
   cu_SkipList_Node *node = (cu_SkipList_Node *)mem.value.ptr;
@@ -51,7 +51,7 @@ static cu_SkipList_Error_Optional cu_SkipList_alloc_node(cu_SkipList *list,
   cu_Slice_Result k = cu_Allocator_Alloc(list->allocator,
       cu_Layout_create(list->key_layout.elem_size,
           list->key_layout.alignment));
-  if (!cu_Slice_result_is_ok(&k)) {
+  if (!cu_Slice_Result_is_ok(&k)) {
     cu_Allocator_Free(list->allocator, mem.value);
     return cu_SkipList_Error_Optional_some(CU_SKIPLIST_ERROR_OOM);
   }
@@ -61,7 +61,7 @@ static cu_SkipList_Error_Optional cu_SkipList_alloc_node(cu_SkipList *list,
   cu_Slice_Result v = cu_Allocator_Alloc(list->allocator,
       cu_Layout_create(list->value_layout.elem_size,
           list->value_layout.alignment));
-  if (!cu_Slice_result_is_ok(&v)) {
+  if (!cu_Slice_Result_is_ok(&v)) {
     cu_Allocator_Free(list->allocator, mem.value);
     cu_Allocator_Free(list->allocator, k.value);
     return cu_SkipList_Error_Optional_some(CU_SKIPLIST_ERROR_OOM);
@@ -78,20 +78,20 @@ cu_SkipList_Result cu_SkipList_create(cu_Allocator allocator,
     cu_Layout key_layout, cu_Layout value_layout, size_t max_level,
     cu_SkipList_CmpFn_Optional cmp) {
   CU_LAYOUT_CHECK(key_layout) {
-    return cu_SkipList_result_error(CU_SKIPLIST_ERROR_INVALID_LAYOUT);
+    return cu_SkipList_Result_error(CU_SKIPLIST_ERROR_INVALID_LAYOUT);
   }
   CU_LAYOUT_CHECK(value_layout) {
-    return cu_SkipList_result_error(CU_SKIPLIST_ERROR_INVALID_LAYOUT);
+    return cu_SkipList_Result_error(CU_SKIPLIST_ERROR_INVALID_LAYOUT);
   }
   if (max_level == 0) {
-    return cu_SkipList_result_error(CU_SKIPLIST_ERROR_INVALID);
+    return cu_SkipList_Result_error(CU_SKIPLIST_ERROR_INVALID);
   }
 
   size_t head_size = sizeof(cu_SkipList_Node) + max_level * sizeof(cu_SkipList_Node *);
   cu_Slice_Result mem = cu_Allocator_Alloc(
       allocator, cu_Layout_create(head_size, alignof(cu_SkipList_Node)));
-  if (!cu_Slice_result_is_ok(&mem)) {
-    return cu_SkipList_result_error(CU_SKIPLIST_ERROR_OOM);
+  if (!cu_Slice_Result_is_ok(&mem)) {
+    return cu_SkipList_Result_error(CU_SKIPLIST_ERROR_OOM);
   }
   cu_SkipList_Node *head = (cu_SkipList_Node *)mem.value.ptr;
   head->forward = (cu_SkipList_Node **)((unsigned char *)head + sizeof(*head));
@@ -113,7 +113,7 @@ cu_SkipList_Result cu_SkipList_create(cu_Allocator allocator,
   list.key_layout = key_layout;
   list.value_layout = value_layout;
   list.allocator = allocator;
-  return cu_SkipList_result_ok(list);
+  return cu_SkipList_Result_ok(list);
 }
 
 void cu_SkipList_destroy(cu_SkipList *list) {

--- a/lib/collection/vector.c
+++ b/lib/collection/vector.c
@@ -14,7 +14,7 @@ CU_OPTIONAL_IMPL(cu_Vector_Error, cu_Vector_Error)
 cu_Vector_Result cu_Vector_create(
     cu_Allocator allocator, cu_Layout layout, Size_Optional initial_capacity) {
   CU_LAYOUT_CHECK(layout) {
-    return cu_Vector_result_error(CU_VECTOR_ERROR_INVALID_LAYOUT);
+    return cu_Vector_Result_error(CU_VECTOR_ERROR_INVALID_LAYOUT);
   }
 
   size_t cap = 0;
@@ -25,8 +25,8 @@ cu_Vector_Result cu_Vector_create(
     cu_Slice_Result r = cu_Allocator_Alloc(
         allocator,
         cu_Layout_create(cap * layout.elem_size, layout.alignment));
-    if (!cu_Slice_result_is_ok(&r)) {
-      return cu_Vector_result_error(CU_VECTOR_ERROR_OOM);
+    if (!cu_Slice_Result_is_ok(&r)) {
+      return cu_Vector_Result_error(CU_VECTOR_ERROR_OOM);
     }
     data = cu_Slice_Optional_some(r.value);
   }
@@ -38,7 +38,7 @@ cu_Vector_Result cu_Vector_create(
   vector.layout = layout;
   vector.allocator = allocator;
 
-  return cu_Vector_result_ok(vector);
+  return cu_Vector_Result_ok(vector);
 }
 
 static cu_Vector_Error_Optional cu_Vector_set_capacity(
@@ -71,7 +71,7 @@ static cu_Vector_Error_Optional cu_Vector_set_capacity(
         cu_Layout_create(capacity * vector->layout.elem_size,
             vector->layout.alignment));
 
-    if (!cu_Slice_result_is_ok(&new_data)) {
+    if (!cu_Slice_Result_is_ok(&new_data)) {
       return cu_Vector_Error_Optional_some(CU_VECTOR_ERROR_OOM);
     }
 
@@ -84,7 +84,7 @@ static cu_Vector_Error_Optional cu_Vector_set_capacity(
       vector->allocator,
       cu_Layout_create(capacity * vector->layout.elem_size,
           vector->layout.alignment));
-  if (!cu_Slice_result_is_ok(&new_data_res)) {
+  if (!cu_Slice_Result_is_ok(&new_data_res)) {
     return cu_Vector_Error_Optional_some(CU_VECTOR_ERROR_OOM);
   }
   vector->data = cu_Slice_Optional_some(new_data_res.value);
@@ -227,15 +227,15 @@ cu_Vector_Error_Optional cu_Vector_pop_front(
 }
 
 cu_Vector_Result cu_Vector_copy(const cu_Vector *src) {
-  CU_IF_NULL(src) { return cu_Vector_result_error(CU_VECTOR_ERROR_INVALID); }
+  CU_IF_NULL(src) { return cu_Vector_Result_error(CU_VECTOR_ERROR_INVALID); }
 
   CU_LAYOUT_CHECK(src->layout) {
-    return cu_Vector_result_error(CU_VECTOR_ERROR_INVALID_LAYOUT);
+    return cu_Vector_Result_error(CU_VECTOR_ERROR_INVALID_LAYOUT);
   }
 
   cu_Vector_Result result = cu_Vector_create(
       src->allocator, src->layout, Size_Optional_some(src->capacity));
-  if (!cu_Vector_result_is_ok(&result)) {
+  if (!cu_Vector_Result_is_ok(&result)) {
     return result;
   }
 

--- a/lib/io/file.c
+++ b/lib/io/file.c
@@ -84,7 +84,7 @@ cu_File_Result cu_File_open(cu_Slice path, cu_File_OpenOptions options) {
         .kind = CU_IO_ERROR_KIND_INVALID_INPUT,
         .errnum = Size_Optional_none(),
     };
-    return cu_File_result_error(error);
+    return cu_File_Result_error(error);
   }
 
   // Convert path to null-terminated string
@@ -107,7 +107,7 @@ cu_File_Result cu_File_open(cu_Slice path, cu_File_OpenOptions options) {
 
   handle = open(lpath, flags, mode);
   if (handle == -1) {
-    return cu_File_result_error(cu_Io_Error_from_errno(errno));
+    return cu_File_Result_error(cu_Io_Error_from_errno(errno));
   }
 #else
   DWORD access = cu_File_OpenOptions_to_win32_access(&options);
@@ -118,12 +118,12 @@ cu_File_Result cu_File_open(cu_Slice path, cu_File_OpenOptions options) {
       creation, attributes, NULL);
 
   if (handle == INVALID_HANDLE_VALUE) {
-    return cu_File_result_error(cu_Io_Error_from_win32(GetLastError()));
+    return cu_File_Result_error(cu_Io_Error_from_win32(GetLastError()));
   }
 #endif
 
   cu_File file = {.handle = handle};
-  return cu_File_result_ok(file);
+  return cu_File_Result_ok(file);
 }
 
 void cu_File_close(cu_File *file) {

--- a/lib/memory/allocator.c
+++ b/lib/memory/allocator.c
@@ -24,7 +24,7 @@ static cu_Slice_Result cu_CAllocator_Alloc(void *self, cu_Layout layout) {
   if (layout.elem_size == 0) {
     cu_Io_Error err = {
         .kind = CU_IO_ERROR_KIND_INVALID_INPUT, .errnum = Size_Optional_none()};
-    return cu_Slice_result_error(err);
+    return cu_Slice_Result_error(err);
   }
 
   size_t size = layout.elem_size;
@@ -36,7 +36,7 @@ static cu_Slice_Result cu_CAllocator_Alloc(void *self, cu_Layout layout) {
   if (raw == NULL) {
     cu_Io_Error err = {
         .kind = CU_IO_ERROR_KIND_OUT_OF_MEMORY, .errnum = Size_Optional_none()};
-    return cu_Slice_result_error(err);
+    return cu_Slice_Result_error(err);
   }
 
   uintptr_t aligned_addr = ((uintptr_t)raw + sizeof(void *) + alignment - 1) &
@@ -44,7 +44,7 @@ static cu_Slice_Result cu_CAllocator_Alloc(void *self, cu_Layout layout) {
   void **store = (void **)aligned_addr - 1;
   *store = raw;
 
-  return cu_Slice_result_ok(cu_Slice_create((void *)aligned_addr, size));
+  return cu_Slice_Result_ok(cu_Slice_create((void *)aligned_addr, size));
 }
 
 static cu_Slice_Result cu_CAllocator_Resize(
@@ -55,14 +55,14 @@ static cu_Slice_Result cu_CAllocator_Resize(
     cu_CAllocator_Free(NULL, mem);
     cu_Io_Error err = {
         .kind = CU_IO_ERROR_KIND_INVALID_INPUT, .errnum = Size_Optional_none()};
-    return cu_Slice_result_error(err);
+    return cu_Slice_Result_error(err);
   }
 
   size_t size = layout.elem_size;
   size_t alignment = layout.alignment;
 
   cu_Slice_Result new_mem = cu_CAllocator_Alloc(self, layout);
-  if (!cu_Slice_result_is_ok(&new_mem)) {
+  if (!cu_Slice_Result_is_ok(&new_mem)) {
     return new_mem;
   }
   size_t copy = mem.length < size ? mem.length : size;
@@ -90,7 +90,7 @@ static cu_Slice_Result cu_null_alloc(void *self, cu_Layout layout) {
   CU_UNUSED(layout);
   cu_Io_Error err = {
       .kind = CU_IO_ERROR_KIND_OUT_OF_MEMORY, .errnum = Size_Optional_none()};
-  return cu_Slice_result_error(err);
+  return cu_Slice_Result_error(err);
 }
 
 static cu_Slice_Result cu_null_resize(
@@ -100,7 +100,7 @@ static cu_Slice_Result cu_null_resize(
   CU_UNUSED(layout);
   cu_Io_Error err = {
       .kind = CU_IO_ERROR_KIND_OUT_OF_MEMORY, .errnum = Size_Optional_none()};
-  return cu_Slice_result_error(err);
+  return cu_Slice_Result_error(err);
 }
 
 static void cu_null_free(void *self, cu_Slice mem) {

--- a/lib/memory/arenaallocator.c
+++ b/lib/memory/arenaallocator.c
@@ -11,7 +11,7 @@ static struct cu_ArenaAllocator_Chunk *cu_arena_create_chunk(
   size_t total = sizeof(struct cu_ArenaAllocator_Chunk) + size;
   cu_Slice_Result mem = cu_Allocator_Alloc(
       arena->backingAllocator, cu_Layout_create(total, alignof(max_align_t)));
-  if (!cu_Slice_result_is_ok(&mem)) {
+  if (!cu_Slice_Result_is_ok(&mem)) {
     return NULL;
   }
   struct cu_ArenaAllocator_Chunk *chunk =
@@ -27,7 +27,7 @@ static cu_Slice_Result cu_arena_alloc(void *self, cu_Layout layout) {
   if (layout.elem_size == 0) {
     cu_Io_Error err = {
         .kind = CU_IO_ERROR_KIND_INVALID_INPUT, .errnum = Size_Optional_none()};
-    return cu_Slice_result_error(err);
+    return cu_Slice_Result_error(err);
   }
   size_t size = layout.elem_size;
   size_t alignment = layout.alignment;
@@ -56,7 +56,7 @@ static cu_Slice_Result cu_arena_alloc(void *self, cu_Layout layout) {
     if (!target) {
       cu_Io_Error err = {.kind = CU_IO_ERROR_KIND_OUT_OF_MEMORY,
           .errnum = Size_Optional_none()};
-      return cu_Slice_result_error(err);
+      return cu_Slice_Result_error(err);
     }
     target->prev = arena->current;
     arena->current = target;
@@ -70,7 +70,7 @@ static cu_Slice_Result cu_arena_alloc(void *self, cu_Layout layout) {
   hdr->chunk = chunk;
   hdr->prev_offset = chunk->used;
   chunk->used = start + size;
-  return cu_Slice_result_ok(cu_Slice_create(chunk->data + start, size));
+  return cu_Slice_Result_ok(cu_Slice_create(chunk->data + start, size));
 }
 
 static cu_Slice_Result cu_arena_resize(
@@ -80,7 +80,7 @@ static cu_Slice_Result cu_arena_resize(
     cu_arena_free(self, mem);
     cu_Io_Error err = {
         .kind = CU_IO_ERROR_KIND_INVALID_INPUT, .errnum = Size_Optional_none()};
-    return cu_Slice_result_error(err);
+    return cu_Slice_Result_error(err);
   }
   size_t size = layout.elem_size;
   size_t alignment = layout.alignment;
@@ -92,19 +92,19 @@ static cu_Slice_Result cu_arena_resize(
   if (!chunk) {
     cu_Io_Error err = {
         .kind = CU_IO_ERROR_KIND_INVALID_INPUT, .errnum = Size_Optional_none()};
-    return cu_Slice_result_error(err);
+    return cu_Slice_Result_error(err);
   }
   if ((unsigned char *)mem.ptr + mem.length == chunk->data + chunk->used) {
     size_t avail = chunk->size - (chunk->used - mem.length);
     if (size <= mem.length + avail) {
       chunk->used = (chunk->used - mem.length) + size;
-      return cu_Slice_result_ok(cu_Slice_create(mem.ptr, size));
+      return cu_Slice_Result_ok(cu_Slice_create(mem.ptr, size));
     }
     // not enough space, fall through
   }
 
   cu_Slice_Result new_mem = cu_arena_alloc(self, layout);
-  if (!cu_Slice_result_is_ok(&new_mem)) {
+  if (!cu_Slice_Result_is_ok(&new_mem)) {
     return new_mem;
   }
   size_t copy = mem.length < size ? mem.length : size;

--- a/lib/memory/fixedallocator.c
+++ b/lib/memory/fixedallocator.c
@@ -10,7 +10,7 @@ static cu_Slice_Result cu_fixed_alloc(void *self, cu_Layout layout) {
   if (layout.elem_size == 0) {
     cu_Io_Error err = {
         .kind = CU_IO_ERROR_KIND_INVALID_INPUT, .errnum = Size_Optional_none()};
-    return cu_Slice_result_error(err);
+    return cu_Slice_Result_error(err);
   }
   size_t size = layout.elem_size;
   size_t alignment = layout.alignment;
@@ -26,7 +26,7 @@ static cu_Slice_Result cu_fixed_alloc(void *self, cu_Layout layout) {
   if (start + size > alloc->buffer.length) {
     cu_Io_Error err = {
         .kind = CU_IO_ERROR_KIND_OUT_OF_MEMORY, .errnum = Size_Optional_none()};
-    return cu_Slice_result_error(err);
+    return cu_Slice_Result_error(err);
   }
 
   struct cu_FixedAllocator_Header *hdr =
@@ -34,7 +34,7 @@ static cu_Slice_Result cu_fixed_alloc(void *self, cu_Layout layout) {
                                           start - header_size);
   hdr->prev_offset = alloc->used;
   alloc->used = start + size;
-  return cu_Slice_result_ok(
+  return cu_Slice_Result_ok(
       cu_Slice_create((unsigned char *)alloc->buffer.ptr + start, size));
 }
 
@@ -46,7 +46,7 @@ static cu_Slice_Result cu_fixed_resize(
     cu_fixed_free(self, mem);
     cu_Io_Error err = {
         .kind = CU_IO_ERROR_KIND_INVALID_INPUT, .errnum = Size_Optional_none()};
-    return cu_Slice_result_error(err);
+    return cu_Slice_Result_error(err);
   }
 
   size_t size = layout.elem_size;
@@ -61,13 +61,13 @@ static cu_Slice_Result cu_fixed_resize(
     size_t avail = alloc->buffer.length - (alloc->used - mem.length);
     if (size <= mem.length + avail) {
       alloc->used = (alloc->used - mem.length) + size;
-      return cu_Slice_result_ok(cu_Slice_create(mem.ptr, size));
+      return cu_Slice_Result_ok(cu_Slice_create(mem.ptr, size));
     }
   }
 
   cu_Slice_Result new_mem =
       cu_fixed_alloc(self, cu_Layout_create(size, alignment));
-  if (!cu_Slice_result_is_ok(&new_mem)) {
+  if (!cu_Slice_Result_is_ok(&new_mem)) {
     return new_mem;
   }
   cu_Memory_memcpy(new_mem.value.ptr,

--- a/lib/memory/page.c
+++ b/lib/memory/page.c
@@ -19,7 +19,7 @@ static cu_Slice_Result cu_PageAllocator_Alloc(void *self, cu_Layout layout) {
   if (layout.elem_size == 0) {
     cu_Io_Error err = {
         .kind = CU_IO_ERROR_KIND_INVALID_INPUT, .errnum = Size_Optional_none()};
-    return cu_Slice_result_error(err);
+    return cu_Slice_Result_error(err);
   }
   size_t size = layout.elem_size;
   size_t aligned_size = CU_ALIGN_UP(size, allocator->pageSize);
@@ -27,9 +27,9 @@ static cu_Slice_Result cu_PageAllocator_Alloc(void *self, cu_Layout layout) {
   if (ptr == NULL) {
     cu_Io_Error err = {
         .kind = CU_IO_ERROR_KIND_OUT_OF_MEMORY, .errnum = Size_Optional_none()};
-    return cu_Slice_result_error(err);
+    return cu_Slice_Result_error(err);
   }
-  return cu_Slice_result_ok(cu_Slice_create(ptr, aligned_size));
+  return cu_Slice_Result_ok(cu_Slice_create(ptr, aligned_size));
 }
 
 static cu_Slice_Result cu_PageAllocator_Resize(
@@ -38,7 +38,7 @@ static cu_Slice_Result cu_PageAllocator_Resize(
     cu_PageAllocator_Free(self, mem);
     cu_Io_Error err = {
         .kind = CU_IO_ERROR_KIND_INVALID_INPUT, .errnum = Size_Optional_none()};
-    return cu_Slice_result_error(err);
+    return cu_Slice_Result_error(err);
   }
 
   size_t size = layout.elem_size;
@@ -49,10 +49,10 @@ static cu_Slice_Result cu_PageAllocator_Resize(
   if (new_ptr == NULL && aligned_size != 0) {
     cu_Io_Error err = {
         .kind = CU_IO_ERROR_KIND_OUT_OF_MEMORY, .errnum = Size_Optional_none()};
-    return cu_Slice_result_error(err);
+    return cu_Slice_Result_error(err);
   }
 
-  return cu_Slice_result_ok(cu_Slice_create(new_ptr, aligned_size));
+  return cu_Slice_Result_ok(cu_Slice_create(new_ptr, aligned_size));
 }
 
 cu_Allocator cu_Allocator_PageAllocator(cu_PageAllocator *allocator) {

--- a/lib/memory/slab.c
+++ b/lib/memory/slab.c
@@ -58,7 +58,7 @@ static struct cu_SlabAllocator_Slab *cu_create_slab(
   cu_Slice_Result mem = cu_Allocator_Alloc(
       alloc->backingAllocator,
       cu_Layout_create(total, alignof(max_align_t)));
-  if (!cu_Slice_result_is_ok(&mem)) {
+  if (!cu_Slice_Result_is_ok(&mem)) {
     return NULL;
   }
   cu_Bitmap_Optional bits = cu_Bitmap_create(alloc->backingAllocator, count);
@@ -80,7 +80,7 @@ static cu_Slice_Result cu_slab_alloc(void *self, cu_Layout layout) {
   if (layout.elem_size == 0) {
     cu_Io_Error err = {
         .kind = CU_IO_ERROR_KIND_INVALID_INPUT, .errnum = Size_Optional_none()};
-    return cu_Slice_result_error(err);
+    return cu_Slice_Result_error(err);
   }
   size_t size = layout.elem_size;
   size_t alignment = layout.alignment;
@@ -90,7 +90,7 @@ static cu_Slice_Result cu_slab_alloc(void *self, cu_Layout layout) {
   if (alignment > alloc->slabSize) {
     cu_Io_Error err = {
         .kind = CU_IO_ERROR_KIND_INVALID_INPUT, .errnum = Size_Optional_none()};
-    return cu_Slice_result_error(err);
+    return cu_Slice_Result_error(err);
   }
 
   size_t needed = alignment - 1 + size + sizeof(struct cu_SlabAllocator_Header);
@@ -119,7 +119,7 @@ static cu_Slice_Result cu_slab_alloc(void *self, cu_Layout layout) {
     if (!slab) {
       cu_Io_Error err = {.kind = CU_IO_ERROR_KIND_OUT_OF_MEMORY,
           .errnum = Size_Optional_none()};
-      return cu_Slice_result_error(err);
+      return cu_Slice_Result_error(err);
     }
     slab->next = alloc->slabs;
     alloc->slabs = slab;
@@ -144,7 +144,7 @@ static cu_Slice_Result cu_slab_alloc(void *self, cu_Layout layout) {
   hdr->slab = slab;
   hdr->index = index;
   hdr->count = need;
-  return cu_Slice_result_ok(cu_Slice_create(data + user_pos, size));
+  return cu_Slice_Result_ok(cu_Slice_create(data + user_pos, size));
 }
 
 static cu_Slice_Result cu_slab_resize(
@@ -155,7 +155,7 @@ static cu_Slice_Result cu_slab_resize(
     cu_slab_free(self, mem);
     cu_Io_Error err = {
         .kind = CU_IO_ERROR_KIND_INVALID_INPUT, .errnum = Size_Optional_none()};
-    return cu_Slice_result_error(err);
+    return cu_Slice_Result_error(err);
   }
 
   size_t size = layout.elem_size;
@@ -169,12 +169,12 @@ static cu_Slice_Result cu_slab_resize(
   size_t prefix = (unsigned char *)mem.ptr - base;
   size_t current = hdr->count * alloc->slabSize - prefix;
   if (size <= current && alignment <= alloc->slabSize) {
-    return cu_Slice_result_ok(cu_Slice_create(mem.ptr, size));
+    return cu_Slice_Result_ok(cu_Slice_create(mem.ptr, size));
   }
 
   cu_Slice_Result new_mem =
       cu_slab_alloc(self, cu_Layout_create(size, alignment));
-  if (!cu_Slice_result_is_ok(&new_mem)) {
+  if (!cu_Slice_Result_is_ok(&new_mem)) {
     return new_mem;
   }
   cu_Memory_memcpy(new_mem.value.ptr,

--- a/lib/memory/wasmallocator.c
+++ b/lib/memory/wasmallocator.c
@@ -65,7 +65,7 @@ static cu_Slice_Result cu_wasm_alloc(void *self, cu_Layout layout) {
   if (layout.elem_size == 0) {
     cu_Io_Error err = {
         .kind = CU_IO_ERROR_KIND_INVALID_INPUT, .errnum = Size_Optional_none()};
-    return cu_Slice_result_error(err);
+    return cu_Slice_Result_error(err);
   }
   size_t size = layout.elem_size;
   size_t alignment = layout.alignment;
@@ -93,7 +93,7 @@ static cu_Slice_Result cu_wasm_alloc(void *self, cu_Layout layout) {
         if (addr == 0) {
           cu_Io_Error err = {.kind = CU_IO_ERROR_KIND_OUT_OF_MEMORY,
               .errnum = Size_Optional_none()};
-          return cu_Slice_result_error(err);
+          return cu_Slice_Result_error(err);
         }
         next_addrs[class] = addr + slot_size;
       } else {
@@ -107,7 +107,7 @@ static cu_Slice_Result cu_wasm_alloc(void *self, cu_Layout layout) {
     if (addr == 0) {
       cu_Io_Error err = {.kind = CU_IO_ERROR_KIND_OUT_OF_MEMORY,
           .errnum = Size_Optional_none()};
-      return cu_Slice_result_error(err);
+      return cu_Slice_Result_error(err);
     }
   }
 
@@ -116,7 +116,7 @@ static cu_Slice_Result cu_wasm_alloc(void *self, cu_Layout layout) {
       (struct cu_WasmAllocator_Header *)(base + user_offset - header_size);
   hdr->offset = user_offset - header_size;
   hdr->slot_size = slot_size;
-  return cu_Slice_result_ok(cu_Slice_create(base + user_offset, size));
+  return cu_Slice_Result_ok(cu_Slice_create(base + user_offset, size));
 }
 
 static cu_Slice_Result cu_wasm_resize(
@@ -126,7 +126,7 @@ static cu_Slice_Result cu_wasm_resize(
     cu_wasm_free(self, mem);
     cu_Io_Error err = {
         .kind = CU_IO_ERROR_KIND_INVALID_INPUT, .errnum = Size_Optional_none()};
-    return cu_Slice_result_error(err);
+    return cu_Slice_Result_error(err);
   }
   size_t size = layout.elem_size;
   size_t alignment = layout.alignment;
@@ -142,12 +142,12 @@ static cu_Slice_Result cu_wasm_resize(
   size_t offset = hdr->offset + sizeof(struct cu_WasmAllocator_Header);
   if (((uintptr_t)mem.ptr % alignment) == 0 &&
       offset + size + sizeof(size_t) <= slot_size) {
-    return cu_Slice_result_ok(cu_Slice_create(mem.ptr, size));
+    return cu_Slice_Result_ok(cu_Slice_create(mem.ptr, size));
   }
 
   cu_Slice_Result new_mem =
       cu_wasm_alloc(self, cu_Layout_create(size, alignment));
-  if (!cu_Slice_result_is_ok(&new_mem)) {
+  if (!cu_Slice_Result_is_ok(&new_mem)) {
     return new_mem;
   }
   cu_Memory_memcpy(new_mem.value.ptr,

--- a/lib/string/string.c
+++ b/lib/string/string.c
@@ -23,7 +23,7 @@ static cu_String_Error cu_string_alloc(cu_String *str, size_t cap) {
         cu_Slice_create(str->data, str->capacity + 1),
         cu_Layout_create(cap + 1, 1));
   }
-  if (!cu_Slice_result_is_ok(&mem)) {
+  if (!cu_Slice_Result_is_ok(&mem)) {
     return CU_STRING_ERROR_OOM;
   }
   str->data = mem.value.ptr;
@@ -52,27 +52,27 @@ cu_String_Result cu_String_from_cstr(cu_Allocator allocator, const char *cstr) {
   cu_String str = cu_String_init(allocator);
   size_t len = cstr ? cu_CString_length(cstr) : 0;
   if (cu_string_alloc(&str, len) != CU_STRING_ERROR_NONE) {
-    return cu_String_result_error(CU_STRING_ERROR_OOM);
+    return cu_String_Result_error(CU_STRING_ERROR_OOM);
   }
   if (len > 0) {
     cu_Memory_memcpy(str.data, cu_Slice_create((void *)cstr, len));
   }
   str.data[len] = '\0';
   str.length = len;
-  return cu_String_result_ok(str);
+  return cu_String_Result_ok(str);
 }
 
 cu_String_Result cu_String_from_slice(cu_Allocator allocator, cu_Slice slice) {
   cu_String str = cu_String_init(allocator);
   if (cu_string_alloc(&str, slice.length) != CU_STRING_ERROR_NONE) {
-    return cu_String_result_error(CU_STRING_ERROR_OOM);
+    return cu_String_Result_error(CU_STRING_ERROR_OOM);
   }
   if (slice.length > 0) {
     cu_Memory_memcpy(str.data, cu_Slice_create(slice.ptr, slice.length));
   }
   str.data[slice.length] = '\0';
   str.length = slice.length;
-  return cu_String_result_ok(str);
+  return cu_String_Result_ok(str);
 }
 
 cu_String_Result cu_String_copy(cu_Allocator allocator, const cu_String *src) {

--- a/tests/test_allocator.cpp
+++ b/tests/test_allocator.cpp
@@ -20,7 +20,7 @@ TEST(Allocator, GPABasic) {
 
   cu_Slice_Result mem_res =
       cu_Allocator_Alloc(alloc, cu_Layout_create(32, 8));
-  ASSERT_TRUE(cu_Slice_result_is_ok(&mem_res));
+  ASSERT_TRUE(cu_Slice_Result_is_ok(&mem_res));
   cu_Slice mem = mem_res.value;
   cu_Memory_memset(mem.ptr, 0xAA, mem.length);
   cu_Allocator_Free(alloc, mem);

--- a/tests/test_arena_allocator.cpp
+++ b/tests/test_arena_allocator.cpp
@@ -20,13 +20,13 @@ TEST(ArenaAllocator, LifoVectors) {
 
   cu_Vector_Result r1 =
       cu_Vector_create(alloc, CU_LAYOUT(int), Size_Optional_some(4));
-  ASSERT_TRUE(cu_Vector_result_is_ok(&r1));
-  cu_Vector v1 = cu_Vector_result_unwrap(&r1);
+  ASSERT_TRUE(cu_Vector_Result_is_ok(&r1));
+  cu_Vector v1 = cu_Vector_Result_unwrap(&r1);
 
   cu_Vector_Result r2 =
       cu_Vector_create(alloc, CU_LAYOUT(float), Size_Optional_some(4));
-  ASSERT_TRUE(cu_Vector_result_is_ok(&r2));
-  cu_Vector v2 = cu_Vector_result_unwrap(&r2);
+  ASSERT_TRUE(cu_Vector_Result_is_ok(&r2));
+  cu_Vector v2 = cu_Vector_Result_unwrap(&r2);
 
   int i = 42;
   float f = 3.14f;
@@ -41,7 +41,7 @@ TEST(ArenaAllocator, LifoVectors) {
 
   cu_Slice_Result reallocation_slice =
       cu_Allocator_Alloc(alloc, cu_Layout_create(16, 4));
-  ASSERT_TRUE(cu_Slice_result_is_ok(&reallocation_slice));
+  ASSERT_TRUE(cu_Slice_Result_is_ok(&reallocation_slice));
   EXPECT_EQ(reallocation_slice.value.ptr, v2_ptr);
   cu_Allocator_Free(alloc, reallocation_slice.value);
 
@@ -62,18 +62,18 @@ TEST(ArenaAllocator, NonLifoAlloc) {
 
   cu_Slice_Result a_res =
       cu_Allocator_Alloc(alloc, cu_Layout_create(16, 8));
-  ASSERT_TRUE(cu_Slice_result_is_ok(&a_res));
+  ASSERT_TRUE(cu_Slice_Result_is_ok(&a_res));
   cu_Slice a = a_res.value;
   cu_Slice_Result b_res =
       cu_Allocator_Alloc(alloc, cu_Layout_create(16, 8));
-  ASSERT_TRUE(cu_Slice_result_is_ok(&b_res));
+  ASSERT_TRUE(cu_Slice_Result_is_ok(&b_res));
   cu_Slice b = b_res.value;
   void *first = a.ptr;
 
   cu_Allocator_Free(alloc, a);
   cu_Slice_Result c_res =
       cu_Allocator_Alloc(alloc, cu_Layout_create(16, 8));
-  ASSERT_TRUE(cu_Slice_result_is_ok(&c_res));
+  ASSERT_TRUE(cu_Slice_Result_is_ok(&c_res));
   cu_Slice c = c_res.value;
   EXPECT_NE(c.ptr, first);
 
@@ -94,7 +94,7 @@ TEST(ArenaAllocator, ChunkReuseStress) {
 
   cu_Slice_Result first_res =
       cu_Allocator_Alloc(alloc, cu_Layout_create(32, 8));
-  ASSERT_TRUE(cu_Slice_result_is_ok(&first_res));
+  ASSERT_TRUE(cu_Slice_Result_is_ok(&first_res));
   cu_Slice first = first_res.value;
   void *ptr = first.ptr;
   cu_Allocator_Free(alloc, first);
@@ -102,7 +102,7 @@ TEST(ArenaAllocator, ChunkReuseStress) {
   for (int i = 0; i < 1000; ++i) {
     cu_Slice_Result slice_res =
         cu_Allocator_Alloc(alloc, cu_Layout_create(32, 8));
-    ASSERT_TRUE(cu_Slice_result_is_ok(&slice_res));
+    ASSERT_TRUE(cu_Slice_Result_is_ok(&slice_res));
     cu_Slice slice = slice_res.value;
     EXPECT_EQ(slice.ptr, ptr);
     cu_Allocator_Free(alloc, slice);
@@ -124,7 +124,7 @@ TEST(ArenaAllocator, ReuseOldChunk) {
   cu_Allocator alloc = cu_Allocator_ArenaAllocator(&arena, cfg);
   cu_Slice_Result first_res =
       cu_Allocator_Alloc(alloc, cu_Layout_create(32, 8));
-  ASSERT_TRUE(cu_Slice_result_is_ok(&first_res));
+  ASSERT_TRUE(cu_Slice_Result_is_ok(&first_res));
   cu_Slice first = first_res.value;
   void *ptr = first.ptr;
 
@@ -133,7 +133,7 @@ TEST(ArenaAllocator, ReuseOldChunk) {
   for (int i = 0; i < 20; ++i) {
     blocks_res[i] =
         cu_Allocator_Alloc(alloc, cu_Layout_create(112, 8));
-    ASSERT_TRUE(cu_Slice_result_is_ok(&blocks_res[i]));
+    ASSERT_TRUE(cu_Slice_Result_is_ok(&blocks_res[i]));
     blocks[i] = blocks_res[i].value;
   }
 
@@ -141,7 +141,7 @@ TEST(ArenaAllocator, ReuseOldChunk) {
 
   cu_Slice_Result again_res =
       cu_Allocator_Alloc(alloc, cu_Layout_create(32, 8));
-  ASSERT_TRUE(cu_Slice_result_is_ok(&again_res));
+  ASSERT_TRUE(cu_Slice_Result_is_ok(&again_res));
   cu_Slice again = again_res.value;
   EXPECT_EQ(again.ptr, ptr);
 
@@ -165,13 +165,13 @@ TEST(ArenaAllocator, ResizeGrowInPlace) {
 
   cu_Slice_Result block_res =
       cu_Allocator_Alloc(alloc, cu_Layout_create(16, 8));
-  ASSERT_TRUE(cu_Slice_result_is_ok(&block_res));
+  ASSERT_TRUE(cu_Slice_Result_is_ok(&block_res));
   cu_Slice block = block_res.value;
   void *ptr = block.ptr;
 
   cu_Slice_Result resized =
       cu_Allocator_Resize(alloc, block, cu_Layout_create(32, 8));
-  ASSERT_TRUE(cu_Slice_result_is_ok(&resized));
+  ASSERT_TRUE(cu_Slice_Result_is_ok(&resized));
   EXPECT_EQ(resized.value.ptr, ptr);
 
   cu_Allocator_Free(alloc, resized.value);
@@ -191,13 +191,13 @@ TEST(ArenaAllocator, ResizeShrinkInPlace) {
 
   cu_Slice_Result block_res =
       cu_Allocator_Alloc(alloc, cu_Layout_create(32, 8));
-  ASSERT_TRUE(cu_Slice_result_is_ok(&block_res));
+  ASSERT_TRUE(cu_Slice_Result_is_ok(&block_res));
   cu_Slice block = block_res.value;
   void *ptr = block.ptr;
 
   cu_Slice_Result resized =
       cu_Allocator_Resize(alloc, block, cu_Layout_create(16, 8));
-  ASSERT_TRUE(cu_Slice_result_is_ok(&resized));
+  ASSERT_TRUE(cu_Slice_Result_is_ok(&resized));
   EXPECT_EQ(resized.value.ptr, ptr);
 
   cu_Allocator_Free(alloc, resized.value);
@@ -217,17 +217,17 @@ TEST(ArenaAllocator, ResizeAllocNewBlock) {
 
   cu_Slice_Result a_res =
       cu_Allocator_Alloc(alloc, cu_Layout_create(16, 8));
-  ASSERT_TRUE(cu_Slice_result_is_ok(&a_res));
+  ASSERT_TRUE(cu_Slice_Result_is_ok(&a_res));
   cu_Slice a = a_res.value;
   cu_Slice_Result b_res =
       cu_Allocator_Alloc(alloc, cu_Layout_create(16, 8));
-  ASSERT_TRUE(cu_Slice_result_is_ok(&b_res));
+  ASSERT_TRUE(cu_Slice_Result_is_ok(&b_res));
   cu_Slice b = b_res.value;
   void *old_ptr = a.ptr;
 
   cu_Slice_Result resized =
       cu_Allocator_Resize(alloc, a, cu_Layout_create(64, 8));
-  ASSERT_TRUE(cu_Slice_result_is_ok(&resized));
+  ASSERT_TRUE(cu_Slice_Result_is_ok(&resized));
   EXPECT_NE(resized.value.ptr, old_ptr);
 
   cu_Allocator_Free(alloc, b);

--- a/tests/test_dlist.cpp
+++ b/tests/test_dlist.cpp
@@ -32,8 +32,8 @@ TEST(DList, PushPop) {
   cu_Allocator alloc = create_allocator(&gpa);
 
   cu_DList_Result res = cu_DList_create(alloc, CU_LAYOUT(int));
-  ASSERT_TRUE(cu_DList_result_is_ok(&res));
-  cu_DList list = cu_DList_result_unwrap(&res);
+  ASSERT_TRUE(cu_DList_Result_is_ok(&res));
+  cu_DList list = cu_DList_Result_unwrap(&res);
 
   for (int i = 0; i < 3; ++i) {
     cu_DList_Error_Optional err = cu_DList_push_back(&list, &i);
@@ -59,8 +59,8 @@ TEST(DList, InsertIter) {
   cu_Allocator alloc = create_allocator(&gpa);
 
   cu_DList_Result res = cu_DList_create(alloc, CU_LAYOUT(int));
-  ASSERT_TRUE(cu_DList_result_is_ok(&res));
-  cu_DList list = cu_DList_result_unwrap(&res);
+  ASSERT_TRUE(cu_DList_Result_is_ok(&res));
+  cu_DList list = cu_DList_Result_unwrap(&res);
 
   for (int i = 0; i < 2; ++i) {
     cu_DList_push_back(&list, &i); // 0,1

--- a/tests/test_file.cpp
+++ b/tests/test_file.cpp
@@ -12,8 +12,8 @@ TEST(File, OpenAndClose) {
   const char lpath[] = "test.txt";
   cu_Slice path = cu_Slice_create((void *)lpath, sizeof(lpath) - 1);
   cu_File_Result res = cu_File_open(path, options);
-  ASSERT_TRUE(cu_File_result_is_ok(&res));
-  cu_File file = cu_File_result_unwrap(&res);
+  ASSERT_TRUE(cu_File_Result_is_ok(&res));
+  cu_File file = cu_File_Result_unwrap(&res);
   EXPECT_NE(file.handle, CU_INVALID_HANDLE);
 
   cu_File_close(&file);

--- a/tests/test_fixed_allocator.cpp
+++ b/tests/test_fixed_allocator.cpp
@@ -13,14 +13,14 @@ TEST(FixedAllocator, Basic) {
 
   cu_Slice_Result a_res =
       cu_Allocator_Alloc(alloc, cu_Layout_create(16, 8));
-  ASSERT_TRUE(cu_Slice_result_is_ok(&a_res));
+  ASSERT_TRUE(cu_Slice_Result_is_ok(&a_res));
   cu_Slice a = a_res.value;
   cu_Memory_memset(a.ptr, 0xAA, a.length);
 
   cu_Allocator_Free(alloc, a);
   cu_Slice_Result b_res =
       cu_Allocator_Alloc(alloc, cu_Layout_create(16, 8));
-  ASSERT_TRUE(cu_Slice_result_is_ok(&b_res));
+  ASSERT_TRUE(cu_Slice_Result_is_ok(&b_res));
   EXPECT_EQ(b_res.value.ptr, a.ptr);
 }
 
@@ -32,8 +32,8 @@ TEST(FixedAllocator, Exhaustion) {
 
   cu_Slice_Result a_res =
       cu_Allocator_Alloc(alloc, cu_Layout_create(24, 8));
-  ASSERT_TRUE(cu_Slice_result_is_ok(&a_res));
+  ASSERT_TRUE(cu_Slice_Result_is_ok(&a_res));
   cu_Slice_Result b_res =
       cu_Allocator_Alloc(alloc, cu_Layout_create(16, 8));
-  ASSERT_FALSE(cu_Slice_result_is_ok(&b_res));
+  ASSERT_FALSE(cu_Slice_Result_is_ok(&b_res));
 }

--- a/tests/test_fmt.cpp
+++ b/tests/test_fmt.cpp
@@ -24,7 +24,7 @@ TEST(StrBuilder, AppendFormatted) {
       CU_STRING_ERROR_NONE, cu_StrBuilder_appendf(&builder, " %s", "items"));
 
   cu_String_Result result = cu_StrBuilder_finalize(&builder);
-  ASSERT_TRUE(cu_String_result_is_ok(&result));
+  ASSERT_TRUE(cu_String_Result_is_ok(&result));
   EXPECT_STREQ(result.value.data, "number 10 items");
   cu_String_destroy(&result.value);
   cu_StrBuilder_destroy(&builder);
@@ -45,7 +45,7 @@ TEST(StrBuilder, AppendAndFinalize) {
   cu_StrBuilder_append_slice(&builder, cu_Slice_create((void *)"ab", 2));
   cu_StrBuilder_append_cstr(&builder, "cd");
   cu_String_Result tmp = cu_String_from_cstr(alloc, "ef");
-  ASSERT_TRUE(cu_String_result_is_ok(&tmp));
+  ASSERT_TRUE(cu_String_Result_is_ok(&tmp));
   cu_StrBuilder_append(&builder, &tmp.value);
   cu_String_destroy(&tmp.value);
 
@@ -53,7 +53,7 @@ TEST(StrBuilder, AppendAndFinalize) {
   EXPECT_EQ(view.length, 6u);
 
   cu_String_Result result = cu_StrBuilder_finalize(&builder);
-  ASSERT_TRUE(cu_String_result_is_ok(&result));
+  ASSERT_TRUE(cu_String_Result_is_ok(&result));
   EXPECT_STREQ(result.value.data, "abcdef");
   cu_String_destroy(&result.value);
   cu_StrBuilder_destroy(&builder);

--- a/tests/test_gpa.cpp
+++ b/tests/test_gpa.cpp
@@ -23,7 +23,7 @@ TEST(Allocator, GPALargeAllocFree) {
   const size_t big = 100 * 1024 * 1024; // 100 MiB
   cu_Slice_Result mem_res =
       cu_Allocator_Alloc(alloc, cu_Layout_create(big, 16));
-  ASSERT_TRUE(cu_Slice_result_is_ok(&mem_res));
+  ASSERT_TRUE(cu_Slice_Result_is_ok(&mem_res));
   cu_Slice mem = mem_res.value;
   cu_Memory_memset(mem.ptr, 0xCD, mem.length);
   cu_Allocator_Free(alloc, mem);
@@ -36,7 +36,7 @@ TEST(Allocator, GPALargeAllocFree) {
   for (size_t i = 0; i < count; ++i) {
     cu_Slice_Result s_res =
         cu_Allocator_Alloc(alloc, cu_Layout_create(small, 16));
-    ASSERT_TRUE(cu_Slice_result_is_ok(&s_res));
+    ASSERT_TRUE(cu_Slice_Result_is_ok(&s_res));
     cu_Slice s = s_res.value;
     cu_Memory_memset(s.ptr, 0xEF, s.length);
     blocks.push_back(s);
@@ -66,7 +66,7 @@ TEST(Allocator, NormalAllocAndFree) {
   cu_Slice_Result res =
       cu_Allocator_Alloc(alloc,
           cu_Layout_create(sizeof(cu_Point), alignof(cu_Point)));
-  ASSERT_TRUE(cu_Slice_result_is_ok(&res));
+  ASSERT_TRUE(cu_Slice_Result_is_ok(&res));
 
   cu_Slice mem = res.value;
   ASSERT_TRUE(mem.ptr != NULL);
@@ -96,7 +96,7 @@ TEST(Allocator, DoubleFree) {
   cu_Slice_Result res =
       cu_Allocator_Alloc(alloc,
           cu_Layout_create(sizeof(cu_Point), alignof(cu_Point)));
-  ASSERT_TRUE(cu_Slice_result_is_ok(&res));
+  ASSERT_TRUE(cu_Slice_Result_is_ok(&res));
 
   cu_Slice mem = res.value;
   ASSERT_TRUE(mem.ptr != NULL);
@@ -126,7 +126,7 @@ TEST(Allocator, Exhaustion) {
       cu_Allocator_Alloc(alloc,
           cu_Layout_create(large_size, alignof(cu_Point)));
 
-  ASSERT_FALSE(cu_Slice_result_is_ok(&res));
+  ASSERT_FALSE(cu_Slice_Result_is_ok(&res));
   EXPECT_EQ(
-      cu_Slice_result_unwrap_error(&res).kind, CU_IO_ERROR_KIND_OUT_OF_MEMORY);
+      cu_Slice_Result_unwrap_error(&res).kind, CU_IO_ERROR_KIND_OUT_OF_MEMORY);
 }

--- a/tests/test_hashmap.cpp
+++ b/tests/test_hashmap.cpp
@@ -38,8 +38,8 @@ TEST(HashMap, BasicInsertGet) {
   cu_HashMap_Result res = cu_HashMap_create(alloc, CU_LAYOUT(int),
       CU_LAYOUT(int), Size_Optional_some(8), cu_HashMap_HashFn_Optional_none(),
       cu_HashMap_EqualsFn_Optional_none());
-  ASSERT_TRUE(cu_HashMap_result_is_ok(&res));
-  cu_HashMap map = cu_HashMap_result_unwrap(&res);
+  ASSERT_TRUE(cu_HashMap_Result_is_ok(&res));
+  cu_HashMap map = cu_HashMap_Result_unwrap(&res);
 
   for (int i = 0; i < 10; ++i) {
     cu_HashMap_insert(&map, &i, &i);
@@ -72,8 +72,8 @@ TEST(HashMap, CustomHashIter) {
       cu_HashMap_create(alloc, CU_LAYOUT(int), CU_LAYOUT(int),
           Size_Optional_some(4), cu_HashMap_HashFn_Optional_some(int_hash),
           cu_HashMap_EqualsFn_Optional_some(int_eq));
-  ASSERT_TRUE(cu_HashMap_result_is_ok(&res));
-  cu_HashMap map = cu_HashMap_result_unwrap(&res);
+  ASSERT_TRUE(cu_HashMap_Result_is_ok(&res));
+  cu_HashMap map = cu_HashMap_Result_unwrap(&res);
 
   for (int i = 0; i < 5; ++i) {
     cu_HashMap_insert(&map, &i, &i);
@@ -100,8 +100,8 @@ TEST(HashMap, StressRandomAccess) {
   cu_HashMap_Result res = cu_HashMap_create(alloc, CU_LAYOUT(int),
       CU_LAYOUT(int), Size_Optional_some(128),
       cu_HashMap_HashFn_Optional_none(), cu_HashMap_EqualsFn_Optional_none());
-  ASSERT_TRUE(cu_HashMap_result_is_ok(&res));
-  cu_HashMap map = cu_HashMap_result_unwrap(&res);
+  ASSERT_TRUE(cu_HashMap_Result_is_ok(&res));
+  cu_HashMap map = cu_HashMap_Result_unwrap(&res);
 
   const int count = 250;
   for (int i = 0; i < count; ++i) {

--- a/tests/test_list.cpp
+++ b/tests/test_list.cpp
@@ -32,8 +32,8 @@ TEST(List, PushPop) {
   cu_Allocator alloc = create_allocator(&gpa);
 
   cu_List_Result res = cu_List_create(alloc, CU_LAYOUT(int));
-  ASSERT_TRUE(cu_List_result_is_ok(&res));
-  cu_List list = cu_List_result_unwrap(&res);
+  ASSERT_TRUE(cu_List_Result_is_ok(&res));
+  cu_List list = cu_List_Result_unwrap(&res);
 
   for (int i = 0; i < 4; ++i) {
     cu_List_Error_Optional err = cu_List_push_front(&list, &i);
@@ -58,8 +58,8 @@ TEST(List, InsertIter) {
   cu_Allocator alloc = create_allocator(&gpa);
 
   cu_List_Result r = cu_List_create(alloc, CU_LAYOUT(int));
-  ASSERT_TRUE(cu_List_result_is_ok(&r));
-  cu_List list = cu_List_result_unwrap(&r);
+  ASSERT_TRUE(cu_List_Result_is_ok(&r));
+  cu_List list = cu_List_Result_unwrap(&r);
 
   for (int i = 0; i < 3; ++i) {
     cu_List_push_front(&list, &i); // 2,1,0

--- a/tests/test_page_allocator.cpp
+++ b/tests/test_page_allocator.cpp
@@ -12,7 +12,7 @@ TEST(PageAllocator, Basic) {
   cu_Allocator a = cu_Allocator_PageAllocator(&palloc);
   cu_Slice_Result mem_res =
       cu_Allocator_Alloc(a, cu_Layout_create(4096, 4096));
-  ASSERT_TRUE(cu_Slice_result_is_ok(&mem_res));
+  ASSERT_TRUE(cu_Slice_Result_is_ok(&mem_res));
   cu_Slice mem = mem_res.value;
   cu_Memory_memset(mem.ptr, 0, mem.length);
   cu_Allocator_Free(a, mem);

--- a/tests/test_ring_buffer.cpp
+++ b/tests/test_ring_buffer.cpp
@@ -28,8 +28,8 @@ TEST(RingBuffer, PushPop) {
   cu_Allocator alloc = create_allocator(&gpa);
 
   cu_RingBuffer_Result res = cu_RingBuffer_create(alloc, CU_LAYOUT(int), 4);
-  ASSERT_TRUE(cu_RingBuffer_result_is_ok(&res));
-  cu_RingBuffer rb = cu_RingBuffer_result_unwrap(&res);
+  ASSERT_TRUE(cu_RingBuffer_Result_is_ok(&res));
+  cu_RingBuffer rb = cu_RingBuffer_Result_unwrap(&res);
 
   for (int i = 0; i < 4; ++i) {
     int v = i;

--- a/tests/test_skip_list.cpp
+++ b/tests/test_skip_list.cpp
@@ -39,8 +39,8 @@ TEST(SkipList, InsertFindRemove) {
 
   cu_SkipList_Result res = cu_SkipList_create(alloc, CU_LAYOUT(int),
       CU_LAYOUT(int), 8, cu_SkipList_CmpFn_Optional_some(int_cmp));
-  ASSERT_TRUE(cu_SkipList_result_is_ok(&res));
-  cu_SkipList list = cu_SkipList_result_unwrap(&res);
+  ASSERT_TRUE(cu_SkipList_Result_is_ok(&res));
+  cu_SkipList list = cu_SkipList_Result_unwrap(&res);
 
   for (int i = 0; i < 10; ++i) {
     cu_SkipList_Error_Optional err = cu_SkipList_insert(&list, &i, &i);
@@ -71,8 +71,8 @@ TEST(SkipList, Iteration) {
 
   cu_SkipList_Result res = cu_SkipList_create(alloc, CU_LAYOUT(int),
       CU_LAYOUT(int), 6, cu_SkipList_CmpFn_Optional_some(int_cmp));
-  ASSERT_TRUE(cu_SkipList_result_is_ok(&res));
-  cu_SkipList list = cu_SkipList_result_unwrap(&res);
+  ASSERT_TRUE(cu_SkipList_Result_is_ok(&res));
+  cu_SkipList list = cu_SkipList_Result_unwrap(&res);
 
   int sum = 0;
   for (int i = 0; i < 5; ++i) {

--- a/tests/test_skip_list_sst.cpp
+++ b/tests/test_skip_list_sst.cpp
@@ -41,8 +41,8 @@ TEST(SkipListSST, SortedStrings) {
 
   cu_SkipList_Result res = cu_SkipList_create(alloc, CU_LAYOUT(const char *),
       CU_LAYOUT(const char *), 6, cu_SkipList_CmpFn_Optional_some(cstring_cmp));
-  ASSERT_TRUE(cu_SkipList_result_is_ok(&res));
-  cu_SkipList list = cu_SkipList_result_unwrap(&res);
+  ASSERT_TRUE(cu_SkipList_Result_is_ok(&res));
+  cu_SkipList list = cu_SkipList_Result_unwrap(&res);
 
   const char *keys[] = {"cherry", "apple", "date", "banana", "elderberry"};
   const char *values[] = {"C", "A", "D", "B", "E"};

--- a/tests/test_slab_allocator.cpp
+++ b/tests/test_slab_allocator.cpp
@@ -20,11 +20,11 @@ TEST(SlabAllocator, Basic) {
 
   cu_Slice_Result a_res =
       cu_Allocator_Alloc(alloc, cu_Layout_create(16, 8));
-  ASSERT_TRUE(cu_Slice_result_is_ok(&a_res));
+  ASSERT_TRUE(cu_Slice_Result_is_ok(&a_res));
   cu_Slice a = a_res.value;
   cu_Slice_Result b_res =
       cu_Allocator_Alloc(alloc, cu_Layout_create(16, 8));
-  ASSERT_TRUE(cu_Slice_result_is_ok(&b_res));
+  ASSERT_TRUE(cu_Slice_Result_is_ok(&b_res));
   cu_Slice b = b_res.value;
   EXPECT_NE(a.ptr, b.ptr);
 
@@ -44,7 +44,7 @@ TEST(SlabAllocator, BigAllocation) {
 
   cu_Slice_Result big_res =
       cu_Allocator_Alloc(alloc, cu_Layout_create(256, 8));
-  ASSERT_TRUE(cu_Slice_result_is_ok(&big_res));
+  ASSERT_TRUE(cu_Slice_Result_is_ok(&big_res));
 
   cu_SlabAllocator_destroy(&slab);
 }
@@ -62,13 +62,13 @@ TEST(SlabAllocator, Resize) {
 
   cu_Slice_Result mem_res =
       cu_Allocator_Alloc(alloc, cu_Layout_create(16, 8));
-  ASSERT_TRUE(cu_Slice_result_is_ok(&mem_res));
+  ASSERT_TRUE(cu_Slice_Result_is_ok(&mem_res));
   cu_Slice mem = mem_res.value;
   cu_Memory_memset(mem.ptr, 0xAA, mem.length);
 
   cu_Slice_Result resized_res =
       cu_Allocator_Resize(alloc, mem, cu_Layout_create(128, 8));
-  ASSERT_TRUE(cu_Slice_result_is_ok(&resized_res));
+  ASSERT_TRUE(cu_Slice_Result_is_ok(&resized_res));
   EXPECT_EQ(((unsigned char *)resized_res.value.ptr)[0], 0xAA);
 
   cu_SlabAllocator_destroy(&slab);
@@ -88,7 +88,7 @@ TEST(SlabAllocator, ManyAllocations) {
   for (int i = 0; i < 1000; ++i) {
     cu_Slice_Result s_res =
         cu_Allocator_Alloc(alloc, cu_Layout_create(8, 4));
-    ASSERT_TRUE(cu_Slice_result_is_ok(&s_res));
+    ASSERT_TRUE(cu_Slice_Result_is_ok(&s_res));
   }
 
   cu_SlabAllocator_destroy(&slab);
@@ -107,14 +107,14 @@ TEST(SlabAllocator, ReuseFreed) {
 
   cu_Slice_Result a_res =
       cu_Allocator_Alloc(alloc, cu_Layout_create(16, 8));
-  ASSERT_TRUE(cu_Slice_result_is_ok(&a_res));
+  ASSERT_TRUE(cu_Slice_Result_is_ok(&a_res));
   cu_Slice a = a_res.value;
   void *ptr = a.ptr;
   cu_Allocator_Free(alloc, a);
 
   cu_Slice_Result b_res =
       cu_Allocator_Alloc(alloc, cu_Layout_create(16, 8));
-  ASSERT_TRUE(cu_Slice_result_is_ok(&b_res));
+  ASSERT_TRUE(cu_Slice_Result_is_ok(&b_res));
   EXPECT_EQ(b_res.value.ptr, ptr);
 
   cu_SlabAllocator_destroy(&slab);
@@ -133,7 +133,7 @@ TEST(SlabAllocator, Alignment) {
 
   cu_Slice_Result res =
       cu_Allocator_Alloc(alloc, cu_Layout_create(8, 16));
-  ASSERT_TRUE(cu_Slice_result_is_ok(&res));
+  ASSERT_TRUE(cu_Slice_Result_is_ok(&res));
   EXPECT_EQ((uintptr_t)res.value.ptr % 16, 0u);
 
   cu_SlabAllocator_destroy(&slab);

--- a/tests/test_string.cpp
+++ b/tests/test_string.cpp
@@ -19,7 +19,7 @@ TEST(String, AppendAndSubstring) {
   cu_Allocator alloc = cu_Allocator_CAllocator();
 #endif
   cu_String_Result res = cu_String_from_cstr(alloc, "hello");
-  ASSERT_TRUE(cu_String_result_is_ok(&res));
+  ASSERT_TRUE(cu_String_Result_is_ok(&res));
   cu_String str = res.value;
 
   EXPECT_EQ(str.length, 5u);
@@ -30,7 +30,7 @@ TEST(String, AppendAndSubstring) {
   EXPECT_STREQ(str.data, "hello, world");
 
   cu_String_Result sub = cu_String_substring(&str, 7, 5);
-  ASSERT_TRUE(cu_String_result_is_ok(&sub));
+  ASSERT_TRUE(cu_String_Result_is_ok(&sub));
   cu_String part = sub.value;
   EXPECT_STREQ(part.data, "world");
 
@@ -50,7 +50,7 @@ TEST(String, Clear) {
   cu_Allocator alloc = cu_Allocator_CAllocator();
 #endif
   cu_String_Result res = cu_String_from_cstr(alloc, "data");
-  ASSERT_TRUE(cu_String_result_is_ok(&res));
+  ASSERT_TRUE(cu_String_Result_is_ok(&res));
   cu_String str = res.value;
   EXPECT_EQ(str.length, 4u);
   cu_String_clear(&str);

--- a/tests/test_vector.cpp
+++ b/tests/test_vector.cpp
@@ -34,8 +34,8 @@ TEST(Vector, Create) {
   cu_Layout layout = CU_LAYOUT(int);
   cu_Vector_Result res =
       cu_Vector_create(alloc, layout, Size_Optional_some(10));
-  ASSERT_TRUE(cu_Vector_result_is_ok(&res));
-  cu_Vector vec = cu_Vector_result_unwrap(&res);
+  ASSERT_TRUE(cu_Vector_Result_is_ok(&res));
+  cu_Vector vec = cu_Vector_Result_unwrap(&res);
   EXPECT_EQ(vec.length, 0u);
   EXPECT_EQ(vec.capacity, 10u);
 
@@ -50,8 +50,8 @@ TEST(Vector, Resize) {
   cu_Layout layout = CU_LAYOUT(int);
   cu_Vector_Result res =
       cu_Vector_create(alloc, layout, Size_Optional_some(10));
-  ASSERT_TRUE(cu_Vector_result_is_ok(&res));
-  cu_Vector vector = cu_Vector_result_unwrap(&res);
+  ASSERT_TRUE(cu_Vector_Result_is_ok(&res));
+  cu_Vector vector = cu_Vector_Result_unwrap(&res);
 
   cu_Vector_Error_Optional err = cu_Vector_resize(&vector, 20);
   ASSERT_TRUE(cu_Vector_Error_Optional_is_none(&err));
@@ -71,8 +71,8 @@ TEST(Vector, PushBack) {
   cu_Allocator alloc = create_allocator(&gpa);
 
   cu_Vector_Result res = cu_Vector_create(alloc, CU_LAYOUT(int), Size_Optional_some(0));
-  ASSERT_TRUE(cu_Vector_result_is_ok(&res));
-  cu_Vector vector = cu_Vector_result_unwrap(&res);
+  ASSERT_TRUE(cu_Vector_Result_is_ok(&res));
+  cu_Vector vector = cu_Vector_Result_unwrap(&res);
 
   int v = 42;
   cu_Vector_Error_Optional err = cu_Vector_push_back(&vector, &v);
@@ -89,8 +89,8 @@ TEST(Vector, PopBack) {
   cu_Allocator alloc = create_allocator(&gpa);
 
   cu_Vector_Result res = cu_Vector_create(alloc, CU_LAYOUT(int), Size_Optional_some(0));
-  ASSERT_TRUE(cu_Vector_result_is_ok(&res));
-  cu_Vector vector = cu_Vector_result_unwrap(&res);
+  ASSERT_TRUE(cu_Vector_Result_is_ok(&res));
+  cu_Vector vector = cu_Vector_Result_unwrap(&res);
 
   int a = 1, b = 2, out = 0;
   cu_Vector_push_back(&vector, &a);
@@ -116,9 +116,9 @@ TEST(Vector, Copy) {
   cu_Allocator alloc = create_allocator(&gpa);
 
   cu_Vector_Result res = cu_Vector_create(alloc, CU_LAYOUT(int), Size_Optional_some(5));
-  ASSERT_TRUE(cu_Vector_result_is_ok(&res));
+  ASSERT_TRUE(cu_Vector_Result_is_ok(&res));
 
-  cu_Vector vector = cu_Vector_result_unwrap(&res);
+  cu_Vector vector = cu_Vector_Result_unwrap(&res);
 
   for (int i = 0; i < 5; ++i) {
     cu_Vector_push_back(&vector, &i);
@@ -127,8 +127,8 @@ TEST(Vector, Copy) {
   ASSERT_EQ(cu_Vector_capacity(&vector), 5u);
 
   cu_Vector_Result copy_res = cu_Vector_copy(&vector);
-  ASSERT_TRUE(cu_Vector_result_is_ok(&copy_res));
-  cu_Vector copy = cu_Vector_result_unwrap(&copy_res);
+  ASSERT_TRUE(cu_Vector_Result_is_ok(&copy_res));
+  cu_Vector copy = cu_Vector_Result_unwrap(&copy_res);
 
   ASSERT_EQ(cu_Vector_size(&copy), 5u);
   ASSERT_EQ(cu_Vector_capacity(&copy), 5u);
@@ -146,8 +146,8 @@ TEST(Vector, ReserveClearAt) {
   cu_Allocator alloc = create_allocator(&gpa);
 
   cu_Vector_Result res = cu_Vector_create(alloc, CU_LAYOUT(int), Size_Optional_some(0));
-  ASSERT_TRUE(cu_Vector_result_is_ok(&res));
-  cu_Vector vector = cu_Vector_result_unwrap(&res);
+  ASSERT_TRUE(cu_Vector_Result_is_ok(&res));
+  cu_Vector vector = cu_Vector_Result_unwrap(&res);
 
   cu_Vector_Error_Optional err = cu_Vector_reserve(&vector, 10);
   ASSERT_TRUE(cu_Vector_Error_Optional_is_none(&err));

--- a/tests/test_wasm_allocator.cpp
+++ b/tests/test_wasm_allocator.cpp
@@ -9,7 +9,7 @@ TEST(WasmAllocator, Basic) {
   cu_Allocator alloc = cu_Allocator_WasmAllocator();
   cu_Slice_Result res =
       cu_Allocator_Alloc(alloc, cu_Layout_create(64, 8));
-  ASSERT_TRUE(cu_Slice_result_is_ok(&res));
+  ASSERT_TRUE(cu_Slice_Result_is_ok(&res));
   cu_Slice mem = res.value;
   cu_Memory_memset(mem.ptr, 0xAA, mem.length);
   cu_Allocator_Free(alloc, mem);


### PR DESCRIPTION
## Summary
- document naming pattern in RFC
- add `CU_CONCAT` macro
- update optional and result helpers to use `CU_OPTIONAL_FN`/`CU_RESULT_FN`
- rename all function calls and examples to use `Result` names
- log the rename in the changelog

## Testing
- `python3 meson-1.8.2/meson.py setup build --reconfigure`
- `ninja -C build`
- `ninja -C build test`


------
https://chatgpt.com/codex/tasks/task_e_6887a080284c8333947599dfa79a05e0