### PR TITLE
Implement Rc destructor support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ All notable changes to this project will be documented in this file. See [conven
 - adds bitmap type - ([d0b722c](https://git.schaub-dev.xyz/cppuniverse/libcute/commit/d0b722cc539b83a4dd722960faba92a604548b6f)) - Fabrice
 - adds faulty vector type - ([05563aa](https://git.schaub-dev.xyz/cppuniverse/libcute/commit/05563aa26c7bf347d5cbd4f4d204d58b81be650f)) - Fabrice
 - copy whole arrays - ([9e54a5f](https://git.schaub-dev.xyz/cppuniverse/libcute/commit/9e54a5f1b2b23f8c57c0d661cbcd157b413d2c35)) - Fabrice
+- add reference counted pointer with destructor support - (unreleased) - Codex
+- remove optional helpers from rc - (unreleased) - Codex
 
 ### Refactoring
 

--- a/include/object/rc.h
+++ b/include/object/rc.h
@@ -1,25 +1,87 @@
 #pragma once
 
+/** @file rc.h Reference counted pointer utilities. */
+
+#include "memory/allocator.h"
+#include "utility.h"
+#include <stdalign.h>
+
 #define CU_RC_NAME(NAME) NAME##_Rc
-/** Construct an optional helper function name. */
+/** Construct a helper function name for the rc type. */
 #define CU_RC_FN(NAME, SUFFIX) CU_CONCAT(CU_RC_NAME(NAME), SUFFIX)
 
-#define CU_RC_HEADER(NAME, T)
-
+/** Container holding the value and reference count. */
+#define CU_RC_DESTRUCTOR_NAME(NAME) CU_RC_FN(NAME, Destructor)
 #define CU_RC_CONTAINER(NAME, T)                                               \
+  typedef void (*CU_RC_DESTRUCTOR_NAME(NAME))(T *);                            \
   typedef struct {                                                             \
     T item;                                                                    \
     size_t ref_count;                                                          \
+    CU_RC_DESTRUCTOR_NAME(NAME) destructor;                                    \
   } CU_RC_FN(NAME, Container);
 
-// ```rs
-//  let rc: Rc<i32> = Rc::new(42);
-//  let rc_clone = rc.clone();
-// ```
+/** Declare functions for a reference counted type. */
+#define CU_RC_HEADER(NAME, T)                                                  \
+  CU_RC_NAME(NAME)                                                             \
+  CU_RC_FN(NAME, _create)(                                                     \
+      cu_Allocator alloc, T value, CU_RC_DESTRUCTOR_NAME(NAME) destructor);    \
+  CU_RC_NAME(NAME) CU_RC_FN(NAME, _clone)(const CU_RC_NAME(NAME) * rc);        \
+  void CU_RC_FN(NAME, _drop)(CU_RC_NAME(NAME) * rc);                           \
+  T *CU_RC_FN(NAME, _get)(const CU_RC_NAME(NAME) * rc);
 
+/** Declare the rc struct and its helpers. */
 #define CU_RC_DECL(NAME, T)                                                    \
-  CU_RC_CONTAINER(NAME, T)                                                  \
+  CU_RC_CONTAINER(NAME, T)                                                     \
   typedef struct {                                                             \
-    CU_RC_FN(NAME, Container) *inner;
-    cu_Allocator alloc;
-  } CU_RC_NAME(NAME);                                                        \
+    CU_RC_FN(NAME, Container) * inner;                                         \
+    cu_Allocator alloc;                                                        \
+  } CU_RC_NAME(NAME);                                                          \
+  CU_RC_HEADER(NAME, T)
+
+/** Define the implementation for the rc helpers. */
+#define CU_RC_IMPL(NAME, T)                                                    \
+  CU_RC_NAME(NAME)                                                             \
+  CU_RC_FN(NAME, _create)(                                                     \
+      cu_Allocator alloc, T value, CU_RC_DESTRUCTOR_NAME(NAME) destructor) {   \
+    cu_Slice_Result mem =                                                      \
+        cu_Allocator_Alloc(alloc, CU_LAYOUT(CU_RC_FN(NAME, Container)));       \
+    CU_RC_NAME(NAME) rc = {0};                                                 \
+    if (!cu_Slice_Result_is_ok(&mem)) {                                        \
+      return rc;                                                               \
+    }                                                                          \
+    CU_RC_FN(NAME, Container) *cont =                                          \
+        (CU_RC_FN(NAME, Container) *)mem.value.ptr;                            \
+    cont->item = value;                                                        \
+    cont->ref_count = 1;                                                       \
+    cont->destructor = destructor;                                             \
+    rc.inner = cont;                                                           \
+    rc.alloc = alloc;                                                          \
+    return rc;                                                                 \
+  }                                                                            \
+  CU_RC_NAME(NAME) CU_RC_FN(NAME, _clone)(const CU_RC_NAME(NAME) * rc) {       \
+    if (!rc || !rc->inner) {                                                   \
+      CU_RC_NAME(NAME) tmp = {0};                                              \
+      return tmp;                                                              \
+    }                                                                          \
+    rc->inner->ref_count++;                                                    \
+    CU_RC_NAME(NAME) clone = {rc->inner, rc->alloc};                           \
+    return clone;                                                              \
+  }                                                                            \
+  void CU_RC_FN(NAME, _drop)(CU_RC_NAME(NAME) * rc) {                          \
+    if (!rc || !rc->inner) {                                                   \
+      return;                                                                  \
+    }                                                                          \
+    if (--rc->inner->ref_count == 0) {                                         \
+      if (rc->inner->destructor) {                                             \
+        rc->inner->destructor(&rc->inner->item);                               \
+      }                                                                        \
+      cu_Allocator_Free(                                                       \
+          rc->alloc, cu_Slice_create(rc->inner, sizeof(*rc->inner)));          \
+    }                                                                          \
+    rc->inner = NULL;                                                          \
+  }                                                                            \
+  T *CU_RC_FN(NAME, _get)(const CU_RC_NAME(NAME) * rc) {                       \
+    CU_IF_NULL(rc) { return NULL; }                                            \
+    CU_IF_NULL(rc->inner) { return NULL; }                                     \
+    return &rc->inner->item;                                                   \
+  }

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -30,6 +30,7 @@ test_files = [
   'test_wasm_allocator.cpp',
   'test_skip_list.cpp',
   'test_skip_list_sst.cpp',
+  'test_rc.cpp',
   'test_file.cpp'
 ]
 

--- a/tests/test_rc.cpp
+++ b/tests/test_rc.cpp
@@ -1,0 +1,31 @@
+#include <gtest/gtest.h>
+extern "C" {
+#include "memory/allocator.h"
+#include "object/rc.h"
+}
+
+CU_RC_DECL(Int, int)
+CU_RC_IMPL(Int, int)
+
+static int drop_count = 0;
+static void int_dtor(int *value) {
+  drop_count++;
+  CU_UNUSED(value);
+}
+
+TEST(Rc, Basic) {
+  cu_Allocator alloc = cu_Allocator_CAllocator();
+  drop_count = 0;
+  Int_Rc rc = Int_Rc_create(alloc, 42, int_dtor);
+  ASSERT_NE(Int_Rc_get(&rc), nullptr);
+
+  EXPECT_EQ(*Int_Rc_get(&rc), 42);
+
+  Int_Rc clone = Int_Rc_clone(&rc);
+  EXPECT_EQ(*Int_Rc_get(&clone), 42);
+
+  Int_Rc_drop(&rc);
+  EXPECT_EQ(*Int_Rc_get(&clone), 42);
+  Int_Rc_drop(&clone);
+  EXPECT_EQ(drop_count, 1);
+}


### PR DESCRIPTION
## Summary
- refine reference counted pointer interface
- drop optional Rc helpers
- keep optional destructor when dropping reference count
- update unit test accordingly

## Testing
- `ninja -C build`
- `meson test -C build`


------
https://chatgpt.com/codex/tasks/task_e_6887aa87c42c83338121778ffeb4f599