### PR TITLE
Add time unit macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ All notable changes to this project will be documented in this file. See [conven
 
 ### Features
 
+- cross-platform file stat and directory handling - Codex
+- expanded file stats with inode, type and nanosecond times - Codex
+- define macros for time constants to remove magic numbers - Codex
+
 - adds changelog - ([50e2d9a](https://git.schaub-dev.xyz/cppuniverse/libcute/commit/50e2d9abe8f10fd4afcc764475bcb4258ca85edb)) - Fabrice
 - adds bitset, starts implementing gpa, fixes macros - ([931d391](https://git.schaub-dev.xyz/cppuniverse/libcute/commit/931d391a6551b651af0f4170bf7e3d2b792b5440)) - Fabrice
 - adds bitmap type - ([d0b722c](https://git.schaub-dev.xyz/cppuniverse/libcute/commit/d0b722cc539b83a4dd722960faba92a604548b6f)) - Fabrice

--- a/include/io/fd.h
+++ b/include/io/fd.h
@@ -1,5 +1,7 @@
 #pragma once
 #include "macro.h"
+#include "utility.h"
+#include <nostd.h>
 #include <stdbool.h>
 #include <stddef.h>
 
@@ -18,25 +20,129 @@ typedef HANDLE cu_Handle;
 #define CU_FILE_MAX_PATH_LENGTH 260
 #endif
 
+typedef enum {
+  CU_FILE_TYPE_UNKNOWN,
+  CU_FILE_TYPE_FILE,
+  CU_FILE_TYPE_DIRECTORY,
+  CU_FILE_TYPE_SYMLINK,
+  CU_FILE_TYPE_NAMED_PIPE,
+  CU_FILE_TYPE_BLOCK_DEVICE,
+  CU_FILE_TYPE_CHAR_DEVICE,
+  CU_FILE_TYPE_SOCKET,
+  CU_FILE_TYPE_DOOR,
+  CU_FILE_TYPE_EVENT_PORT,
+} cu_File_Type;
+
 typedef struct {
-  size_t length;
-  bool is_dir;
-  size_t mtime;
-  size_t ctime;
-  size_t atime;
+  unsigned long long inode;
+  unsigned long long size;
+  unsigned int mode;
+  cu_File_Type kind;
+  long long atime;
+  long long mtime;
+  long long ctime;
 } cu_File_Stat;
 
 #if CU_PLAT_POSIX
+#include <sys/types.h>
 #include <sys/stat.h>
-cu_File_Stat cu_File_Stat_from(struct stat *st) {
-  return (cu_File_Stat){
-      .length = st->st_size,
-      .is_dir = S_ISDIR(st->st_mode),
-      .mtime = st->st_mtime,
-      .ctime = st->st_ctime,
-      .atime = st->st_atime,
-  };
+static inline cu_File_Stat cu_File_Stat_from_handle(cu_Handle handle) {
+  struct stat st;
+  cu_Memory_memset(&st, 0, sizeof(st));
+  cu_File_Stat out;
+  cu_Memory_memset(&out, 0, sizeof(out));
+  if (fstat(handle, &st) != 0) {
+    return out;
+  }
+
+  out.inode = (unsigned long long)st.st_ino;
+  out.size = (unsigned long long)st.st_size;
+  out.mode = (unsigned int)st.st_mode;
+
+  if (S_ISREG(st.st_mode)) {
+    out.kind = CU_FILE_TYPE_FILE;
+  } else if (S_ISDIR(st.st_mode)) {
+    out.kind = CU_FILE_TYPE_DIRECTORY;
+  } else if (S_ISCHR(st.st_mode)) {
+    out.kind = CU_FILE_TYPE_CHAR_DEVICE;
+  } else if (S_ISBLK(st.st_mode)) {
+    out.kind = CU_FILE_TYPE_BLOCK_DEVICE;
+  } else if (S_ISFIFO(st.st_mode)) {
+    out.kind = CU_FILE_TYPE_NAMED_PIPE;
+  } else if (S_ISLNK(st.st_mode)) {
+    out.kind = CU_FILE_TYPE_SYMLINK;
+#ifdef S_ISSOCK
+  } else if (S_ISSOCK(st.st_mode)) {
+    out.kind = CU_FILE_TYPE_SOCKET;
+#endif
+#ifdef S_IFDOOR
+  } else if ((st.st_mode & S_IFMT) == S_IFDOOR) {
+    out.kind = CU_FILE_TYPE_DOOR;
+#endif
+#ifdef S_IFPORT
+  } else if ((st.st_mode & S_IFMT) == S_IFPORT) {
+    out.kind = CU_FILE_TYPE_EVENT_PORT;
+#endif
+  } else {
+    out.kind = CU_FILE_TYPE_UNKNOWN;
+  }
+
+#ifdef __APPLE__
+  out.atime = (long long)st.st_atimespec.tv_sec * CU_TIME_NS_PER_SEC +
+              st.st_atimespec.tv_nsec;
+  out.mtime = (long long)st.st_mtimespec.tv_sec * CU_TIME_NS_PER_SEC +
+              st.st_mtimespec.tv_nsec;
+  out.ctime = (long long)st.st_ctimespec.tv_sec * CU_TIME_NS_PER_SEC +
+              st.st_ctimespec.tv_nsec;
+#elif defined(_STATBUF_ST_NSEC) && defined(st_atim)
+  out.atime = (long long)st.st_atim.tv_sec * CU_TIME_NS_PER_SEC +
+              st.st_atim.tv_nsec;
+  out.mtime = (long long)st.st_mtim.tv_sec * CU_TIME_NS_PER_SEC +
+              st.st_mtim.tv_nsec;
+  out.ctime = (long long)st.st_ctim.tv_sec * CU_TIME_NS_PER_SEC +
+              st.st_ctim.tv_nsec;
+#elif defined(_STATBUF_ST_NSEC)
+  out.atime = (long long)st.st_atime * CU_TIME_NS_PER_SEC + st.st_atimensec;
+  out.mtime = (long long)st.st_mtime * CU_TIME_NS_PER_SEC + st.st_mtimensec;
+  out.ctime = (long long)st.st_ctime * CU_TIME_NS_PER_SEC + st.st_ctimensec;
+#else
+  out.atime = (long long)st.st_atime * CU_TIME_NS_PER_SEC;
+  out.mtime = (long long)st.st_mtime * CU_TIME_NS_PER_SEC;
+  out.ctime = (long long)st.st_ctime * CU_TIME_NS_PER_SEC;
+#endif
+
+  return out;
 }
 #else
-#error "Windows implementation not yet supported"
+#include <windows.h>
+static inline cu_File_Stat cu_File_Stat_from_handle(cu_Handle handle) {
+  BY_HANDLE_FILE_INFORMATION info;
+  cu_File_Stat out;
+  cu_Memory_memset(&out, 0, sizeof(out));
+  if (!GetFileInformationByHandle(handle, &info)) {
+    return out;
+  }
+  ULARGE_INTEGER size;
+  size.HighPart = info.nFileSizeHigh;
+  size.LowPart = info.nFileSizeLow;
+
+  out.inode = ((unsigned long long)info.nFileIndexHigh << 32) |
+              info.nFileIndexLow;
+  out.size = (unsigned long long)size.QuadPart;
+  out.mode = info.dwFileAttributes;
+  if (info.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
+    out.kind = CU_FILE_TYPE_DIRECTORY;
+  } else if (info.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) {
+    out.kind = CU_FILE_TYPE_SYMLINK;
+  } else {
+    out.kind = CU_FILE_TYPE_FILE;
+  }
+
+  out.mtime = cu_Time_filetime_to_unix(info.ftLastWriteTime);
+  out.ctime = cu_Time_filetime_to_unix(info.ftCreationTime);
+  out.atime = cu_Time_filetime_to_unix(info.ftLastAccessTime);
+
+  return out;
+}
 #endif
+

--- a/include/utility.h
+++ b/include/utility.h
@@ -37,3 +37,13 @@ static inline cu_Layout cu_Layout_create(size_t elem_size, size_t alignment) {
 #define CU_LAYOUT(T) cu_Layout_create(sizeof(T), _Alignof(T))
 #define CU_LAYOUT_CHECK(layout)                                                \
   if ((layout).elem_size == 0 || (layout).alignment == 0)
+
+#define CU_TIME_NS_PER_SEC 1000000000ULL
+#if CU_PLAT_WINDOWS
+#define CU_TIME_WINDOWS_TICKS_PER_SEC 10000000ULL
+#define CU_TIME_WINDOWS_EPOCH_DIFF 116444736000000000ULL
+#define CU_TIME_WINDOWS_TICK_NS 100ULL
+#include <windows.h>
+long long cu_Time_filetime_to_unix(FILETIME ft);
+FILETIME cu_Time_unix_to_filetime(long long ns);
+#endif

--- a/lib/utility.c
+++ b/lib/utility.c
@@ -1,0 +1,21 @@
+#include "utility.h"
+
+#if CU_PLAT_WINDOWS
+long long cu_Time_filetime_to_unix(FILETIME ft) {
+  ULARGE_INTEGER uli;
+  uli.LowPart = ft.dwLowDateTime;
+  uli.HighPart = ft.dwHighDateTime;
+  return (long long)((uli.QuadPart - CU_TIME_WINDOWS_EPOCH_DIFF) *
+                     CU_TIME_WINDOWS_TICK_NS);
+}
+
+FILETIME cu_Time_unix_to_filetime(long long ns) {
+  ULARGE_INTEGER uli;
+  uli.QuadPart = (unsigned long long)(ns / CU_TIME_WINDOWS_TICK_NS) +
+                 CU_TIME_WINDOWS_EPOCH_DIFF;
+  FILETIME ft;
+  ft.dwLowDateTime = uli.LowPart;
+  ft.dwHighDateTime = uli.HighPart;
+  return ft;
+}
+#endif

--- a/meson.build
+++ b/meson.build
@@ -23,6 +23,7 @@ sources = [
   'lib/string/string.c',
   'lib/string/fmt.c',
   'lib/nostd.c',
+  'lib/utility.c',
   'lib/collection/ring_buffer.c',
   'lib/collection/list.c',
   'lib/collection/dlist.c',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -30,7 +30,8 @@ test_files = [
   'test_skip_list.c',
   'test_skip_list_sst.c',
   'test_rc.c',
-  'test_file.c'
+  'test_file.c',
+  'test_dir.c'
 ]
 
 foreach test_file : test_files

--- a/tests/test_dir.c
+++ b/tests/test_dir.c
@@ -1,0 +1,22 @@
+#include "cute.h"
+#include "unity.h"
+#include <nostd.h>
+#include "io/dir.h"
+
+static void Dir_OpenClose(void) {
+  const char path_c[] = ".";
+  cu_Slice path = cu_Slice_create((void *)path_c, sizeof(path_c) - 1);
+  cu_Dir_Result res = cu_Dir_open(path, false);
+  TEST_ASSERT_TRUE(cu_Dir_Result_is_ok(&res));
+  cu_Dir dir = cu_Dir_Result_unwrap(&res);
+  TEST_ASSERT_TRUE(dir.handle != CU_INVALID_HANDLE);
+  TEST_ASSERT_EQUAL(dir.stat.kind, CU_FILE_TYPE_DIRECTORY);
+  cu_Dir_close(&dir);
+  TEST_ASSERT_EQUAL(dir.handle, CU_INVALID_HANDLE);
+}
+
+int main(void) {
+  UNITY_BEGIN();
+  RUN_TEST(Dir_OpenClose);
+  return UNITY_END();
+}


### PR DESCRIPTION
## Summary
- avoid raw numbers in time conversions
- include `utility.h` for time macros in the stat helpers
- document the new macros in the changelog

## Testing
- `python3 meson-1.8.2/meson.py setup build -Dtests=enabled`
- `ninja -C build`
- `ninja -C build test`


------
https://chatgpt.com/codex/tasks/task_e_6888a5a6287483338753aa665fbcce5b