### PR TITLE
Add cu_FStream_openat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ All notable changes to this project will be documented in this file. See [conven
 - copy whole arrays - ([9e54a5f](https://git.schaub-dev.xyz/cppuniverse/libcute/commit/9e54a5f1b2b23f8c57c0d661cbcd157b413d2c35)) - Fabrice
 - implement directory path helpers - Fabrice
 - add cu_Dir_openat using portable path construction - Fabrice
+- add cu_FStream_openat for directory relative streams - Codex
 
 ### Refactoring
 

--- a/include/io/fstream.h
+++ b/include/io/fstream.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "collection/ring_buffer.h"
+#include "io/dir.h"
 #include "io/error.h"
 #include "io/file.h"
 #include "io/stream.h"
@@ -21,6 +22,8 @@ CU_RESULT_DECL(cu_FStream, cu_FStream, cu_Io_Error)
 
 cu_FStream_Result cu_FStream_open(cu_Slice path, cu_File_Options options,
     size_t buffer_size, cu_Allocator allocator);
+cu_FStream_Result cu_FStream_openat(cu_Dir *dir, cu_Slice path,
+    cu_File_Options options, size_t buffer_size, cu_Allocator allocator);
 /** View the fstream as a generic stream interface. */
 cu_Stream cu_FStream_stream(cu_FStream *fs);
 cu_Io_Error_Optional cu_FStream_flush(cu_FStream *stream);


### PR DESCRIPTION
## Summary
- add `cu_FStream_openat` API and use in tests
- support directory-relative buffered stream operations

## Testing
- `ninja -C build`
- `.venv/bin/meson test -C build`

------
https://chatgpt.com/codex/tasks/task_e_688a14223a148333a1845b0238d0333d